### PR TITLE
feat: improve vehicle spawner

### DIFF
--- a/src/game/features/vehicle/Spawn.cpp
+++ b/src/game/features/vehicle/Spawn.cpp
@@ -11,6 +11,8 @@ namespace YimMenu::Features
 	static StringCommand _VehicleModelname{"vehmodelname", "Vehicle model name", "The model name of the vehicle you wish to spawn."};
 	static BoolCommand _SpawnInVehicle{"spawninvehicle", "Spawn in vehicle", "Enter vehicle once it is spawned", false};
 	static BoolCommand _SpawnWithMaximumUpgrades{"spawnupgraded", "Spawn with maximum upgrades", "Spawn vehicle with maximum upgrades", false};
+	static BoolCommand _UseCustomLicensePlate{"usecustomlicenseplate", "Use custom license plate", "Use a custom license plate for the vehicle", false};
+	static StringCommand _CustomLicensePlate{"customlicenseplate", "Custom license plate", "The custom license plate for the vehicle"};
 
 	class SpawnVehicle : public Command {
 		using Command::Command;
@@ -43,6 +45,20 @@ namespace YimMenu::Features
 				if (_SpawnWithMaximumUpgrades.GetState())
 				{
 					veh.Upgrade();
+				}
+
+				if (_UseCustomLicensePlate.GetState())
+				{
+					std::string licensePlate = _CustomLicensePlate.GetString();
+
+					if (licensePlate.length() > 8)
+					{
+						Notifications::Show("Spawn Vehicle", "License plate must be 8 characters or less.", NotificationType::Error);
+					}
+					else if (licensePlate.length() > 0)
+					{
+						veh.SetPlateText(licensePlate);
+					}				
 				}
 			}
 			else

--- a/src/game/features/vehicle/Spawn.cpp
+++ b/src/game/features/vehicle/Spawn.cpp
@@ -4,6 +4,7 @@
 #include "core/backend/ScriptMgr.hpp"
 #include "core/commands/BoolCommand.hpp"
 #include "game/gta/data/VehicleValues.hpp"
+#include "core/frontend/Notifications.hpp"
 
 namespace YimMenu::Features
 {
@@ -17,35 +18,36 @@ namespace YimMenu::Features
 		virtual void OnCall() override
 		{
 			auto model = _VehicleModelname.GetString();
+			
+			if (!model.length())
+			{
+				Notifications::Show("Spawn Vehicle", "No model name provided.", NotificationType::Error);
+				return;
+			}
 
 			Hash modelHash = Joaat(model);
 
-			if (!modelHash)
-			{
-				LOG(WARNING) << "Couldn't spawn vehicle because no model name was specified.";
-				return;
-			}
+			assert(modelHash != 0);
 
 			if (STREAMING::IS_MODEL_IN_CDIMAGE(modelHash))
 			{
 				rage::fvector3 coords = Self::GetPed().GetPosition();
-				auto veh              = Vehicle::Create(modelHash, coords, Self::GetPed().GetHeading()).GetHandle();
+				auto veh              = Vehicle::Create(modelHash, coords, Self::GetPed().GetHeading());
+				auto vehHandle        = veh.GetHandle();
 
 				if (_SpawnInVehicle.GetState())
 				{
-					PED::SET_PED_INTO_VEHICLE(Self::GetPed().GetHandle(), veh, -1);
+					PED::SET_PED_INTO_VEHICLE(Self::GetPed().GetHandle(), vehHandle, -1);
 				}
 
 				if (_SpawnWithMaximumUpgrades.GetState())
 				{
-					VEHICLE::SET_VEHICLE_MOD_KIT(veh, 0);
-				
-					for (int t = (int)VehicleModType::MOD_SPOILERS; t < (int)VehicleModType::MOD_LIGHTBAR; t++) {
-						VEHICLE::SET_VEHICLE_MOD(veh, t, VEHICLE::GET_NUM_VEHICLE_MODS(veh, t) - 1, false);
-					}
-
-					VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(veh, false);
+					veh.Upgrade();
 				}
+			}
+			else
+			{
+				Notifications::Show("Spawn Vehicle", "Invalid model name provided.", NotificationType::Error);
 			}
 		}
 	};

--- a/src/game/frontend/submenus/World.cpp
+++ b/src/game/frontend/submenus/World.cpp
@@ -12,6 +12,8 @@ namespace YimMenu::Submenus
 		spawnGroup->AddItem(std::make_shared<StringCommandItem>("vehmodelname"_J));
 		spawnGroup->AddItem(std::make_shared<BoolCommandItem>("spawninvehicle"_J));
 		spawnGroup->AddItem(std::make_shared<BoolCommandItem>("spawnupgraded"_J));
+		spawnGroup->AddItem(std::make_shared<BoolCommandItem>("usecustomlicenseplate"_J));
+		spawnGroup->AddItem(std::make_shared<ConditionalItem>("usecustomlicenseplate"_J, std::make_shared<StringCommandItem>("customlicenseplate"_J)));
 		spawnGroup->AddItem(std::make_shared<CommandItem>("spawnvehicle"_J));
 
 		mainGroup->AddItem(spawnGroup);

--- a/src/game/gta/Vehicle.cpp
+++ b/src/game/gta/Vehicle.cpp
@@ -98,4 +98,15 @@ namespace YimMenu
 
 		VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(veh, false);
 	}
+
+	void Vehicle::SetPlateText(const std::string text)
+	{
+		if (text.length() > 8)
+		{
+			return;
+		}
+
+		const char* cstr = text.c_str();
+		VEHICLE::SET_VEHICLE_NUMBER_PLATE_TEXT(GetHandle(), cstr);
+	}
 }

--- a/src/game/gta/Vehicle.cpp
+++ b/src/game/gta/Vehicle.cpp
@@ -2,6 +2,7 @@
 #include "Natives.hpp"
 #include "core/backend/ScriptMgr.hpp"
 #include "game/pointers/Pointers.hpp"
+#include "game/gta/data/VehicleValues.hpp"
 
 namespace YimMenu
 {
@@ -82,5 +83,19 @@ namespace YimMenu
 		ENTITY_ASSERT_VALID();
 
 		return VEHICLE::GET_VEHICLE_ESTIMATED_MAX_SPEED(GetHandle());
+	}
+
+	void Vehicle::Upgrade()
+	{
+		auto veh = GetHandle();
+
+		VEHICLE::SET_VEHICLE_MOD_KIT(veh, 0);
+
+		for (int t = (int)VehicleModType::MOD_SPOILERS; t < (int)VehicleModType::MOD_LIGHTBAR; t++)
+		{
+			VEHICLE::SET_VEHICLE_MOD(veh, t, VEHICLE::GET_NUM_VEHICLE_MODS(veh, t) - 1, false);
+		}
+
+		VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(veh, false);
 	}
 }

--- a/src/game/gta/Vehicle.cpp
+++ b/src/game/gta/Vehicle.cpp
@@ -87,6 +87,9 @@ namespace YimMenu
 
 	void Vehicle::Upgrade()
 	{
+		ENTITY_ASSERT_VALID();
+		ENTITY_ASSERT_CONTROL();
+
 		auto veh = GetHandle();
 
 		VEHICLE::SET_VEHICLE_MOD_KIT(veh, 0);
@@ -101,6 +104,9 @@ namespace YimMenu
 
 	void Vehicle::SetPlateText(const std::string text)
 	{
+		ENTITY_ASSERT_VALID();
+		ENTITY_ASSERT_CONTROL();
+
 		if (text.length() > 8)
 		{
 			return;

--- a/src/game/gta/Vehicle.hpp
+++ b/src/game/gta/Vehicle.hpp
@@ -18,5 +18,7 @@ namespace YimMenu
 
 		// speed
 		float GetMaxSpeed();
+
+		void Upgrade();
 	};
 }

--- a/src/game/gta/Vehicle.hpp
+++ b/src/game/gta/Vehicle.hpp
@@ -20,5 +20,6 @@ namespace YimMenu
 		float GetMaxSpeed();
 
 		void Upgrade();
+		void SetPlateText(const std::string text);
 	};
 }


### PR DESCRIPTION
Various improvements to the vehicle spawner:
  - Implement Vehicle::SetPlateText
  - Add license plate customization to vehicle spawner
  - Move vehicle upgrade/mod logic to Vehicle class (Vehicle::Upgrade)
  - Vehicle Spawner displays error notifications if model name is not provided or is invalid
  
  
![image](https://github.com/user-attachments/assets/765dc12d-be3b-4790-9552-1857827a7eec)
