### PR TITLE
Fix read packed int not working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,23 +12,10 @@ include(cmake/minhook.cmake)
 
 # source
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/src")
-
-function(GroupSourcesAndCollect curdir outputVar)
-    file(GLOB children RELATIVE ${CMAKE_SOURCE_DIR}/${curdir} ${CMAKE_SOURCE_DIR}/${curdir}/*)
-    foreach(child ${children})
-        if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/${curdir}/${child})
-            GroupSourcesAndCollect(${curdir}/${child} ${outputVar})
-        else()
-            list(APPEND ${outputVar} ${CMAKE_SOURCE_DIR}/${curdir}/${child})
-            string(REPLACE "/" "\\" groupname ${curdir})
-            source_group(${groupname} FILES ${CMAKE_SOURCE_DIR}/${curdir}/${child})
-        endif()
-    endforeach()
-    set(${outputVar} ${${outputVar}} PARENT_SCOPE)
-endfunction()
-
-set(SRC_FILES)
-GroupSourcesAndCollect(src SRC_FILES)
+file(GLOB_RECURSE SRC_FILES
+    "${SRC_DIR}/**.hpp"
+    "${SRC_DIR}/**.cpp"    
+)
 
 add_library(${PROJECT_NAME} MODULE ${SRC_FILES})
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 23)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,23 @@ include(cmake/minhook.cmake)
 
 # source
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/src")
-file(GLOB_RECURSE SRC_FILES
-    "${SRC_DIR}/**.hpp"
-    "${SRC_DIR}/**.cpp"    
-)
+
+function(GroupSourcesAndCollect curdir outputVar)
+    file(GLOB children RELATIVE ${CMAKE_SOURCE_DIR}/${curdir} ${CMAKE_SOURCE_DIR}/${curdir}/*)
+    foreach(child ${children})
+        if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/${curdir}/${child})
+            GroupSourcesAndCollect(${curdir}/${child} ${outputVar})
+        else()
+            list(APPEND ${outputVar} ${CMAKE_SOURCE_DIR}/${curdir}/${child})
+            string(REPLACE "/" "\\" groupname ${curdir})
+            source_group(${groupname} FILES ${CMAKE_SOURCE_DIR}/${curdir}/${child})
+        endif()
+    endforeach()
+    set(${outputVar} ${${outputVar}} PARENT_SCOPE)
+endfunction()
+
+set(SRC_FILES)
+GroupSourcesAndCollect(src SRC_FILES)
 
 add_library(${PROJECT_NAME} MODULE ${SRC_FILES})
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 23)

--- a/src/game/frontend/Menu.cpp
+++ b/src/game/frontend/Menu.cpp
@@ -40,7 +40,7 @@ namespace YimMenu
 			    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImU32(ImColor(15, 15, 15)));
 
 			    ImGui::SetNextWindowSize(ImVec2((*Pointers.ScreenResX / 2.5), (*Pointers.ScreenResY / 2.5)), ImGuiCond_Once);
-			    if (ImGui::Begin("YimMenuV2", nullptr, ImGuiWindowFlags_NoDecoration&~ImGuiWindowFlags_NoResize))
+			    if (ImGui::Begin("YimMenuV2", nullptr, ImGuiWindowFlags_NoDecoration))
 			    {
 				    //ImGui::BeginDisabled(*Pointers.IsSessionStarted);
 				    if (ImGui::Button("Unload", ImVec2(120, 0)))

--- a/src/game/frontend/Menu.cpp
+++ b/src/game/frontend/Menu.cpp
@@ -111,6 +111,8 @@ namespace YimMenu
 	void Menu::SetupFonts()
 	{
 		auto& IO = ImGui::GetIO();
+		IO.IniFilename = NULL;
+		IO.LogFilename = NULL;
 		ImFontConfig FontCfg{};
 		FontCfg.FontDataOwnedByAtlas = false;
 

--- a/src/game/frontend/Menu.cpp
+++ b/src/game/frontend/Menu.cpp
@@ -1,5 +1,6 @@
 #include "Menu.hpp"
-
+#include "imgui.h"
+#include "imgui_internal.h"
 #include "core/commands/Commands.hpp"
 #include "core/frontend/manager/UIManager.hpp"
 #include "core/renderer/Renderer.hpp"
@@ -15,7 +16,7 @@
 #include "submenus/Settings.hpp"
 #include "submenus/Debug.hpp"
 #include "submenus/World.hpp"
-
+#include "core/filemgr/FileMgr.hpp"
 namespace YimMenu
 {
 	void Menu::Init()
@@ -39,7 +40,7 @@ namespace YimMenu
 			    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImU32(ImColor(15, 15, 15)));
 
 			    ImGui::SetNextWindowSize(ImVec2((*Pointers.ScreenResX / 2.5), (*Pointers.ScreenResY / 2.5)), ImGuiCond_Once);
-			    if (ImGui::Begin("YimMenuV2", nullptr, ImGuiWindowFlags_NoDecoration))
+			    if (ImGui::Begin("YimMenuV2", nullptr, ImGuiWindowFlags_NoDecoration&~ImGuiWindowFlags_NoResize))
 			    {
 				    //ImGui::BeginDisabled(*Pointers.IsSessionStarted);
 				    if (ImGui::Button("Unload", ImVec2(120, 0)))
@@ -110,9 +111,11 @@ namespace YimMenu
 
 	void Menu::SetupFonts()
 	{
-		auto& IO = ImGui::GetIO();
-		IO.IniFilename = NULL;
-		IO.LogFilename = NULL;
+		auto& IO         = ImGui::GetIO();
+		auto file_path   = std::filesystem::path(std::getenv("appdata")) / "YimMenuV2" / "imgui.ini";
+		std::string path = file_path.string();
+		IO.IniFilename   = path.c_str();
+		IO.LogFilename   = NULL;
 		ImFontConfig FontCfg{};
 		FontCfg.FontDataOwnedByAtlas = false;
 

--- a/src/game/frontend/submenus/Recovery/StatEditor.cpp
+++ b/src/game/frontend/submenus/Recovery/StatEditor.cpp
@@ -203,7 +203,7 @@ namespace YimMenu::Submenus
 		if (info.m_IsBoolStat)
 			value.m_AsBool = STATS::GET_PACKED_STAT_BOOL_CODE(info.m_Index, -1);
 		else
-			value.m_AsInt = STATS::GET_PACKED_STAT_BOOL_CODE(info.m_Index, -1);
+			value.m_AsInt = STATS::GET_PACKED_STAT_INT_CODE(info.m_Index, -1);
 	}
 
 	static void WritePackedStat(const StatValue& value, const PackedStatInfo& info)
@@ -224,8 +224,6 @@ namespace YimMenu::Submenus
 
 			if (info.m_IsBoolStat)
 				STATS::SET_PACKED_STAT_BOOL_CODE(info.m_Index, static_cast<bool>(value), -1);
-			else
-				STATS::SET_PACKED_STAT_INT_CODE(info.m_Index, value, -1);
 		}
 	}
 


### PR DESCRIPTION
1. Fix read packed int not working
2. Remove the scope setting packed int (because packed int misoperation will damage the account and there is no need to modify it in bulk)
3. A configuration file that does not generate imgui.ini in the root directory of the game