### PR TITLE
Anticheat bypass adapted for FSL v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Experimental menu for GTA 5: Enhanced
 
 ## How to use
 
-1. Download the latest version of FSL from [here](https://www.unknowncheats.me/forum/grand-theft-auto-v/616977-fsl-local-gtao-saves.html) and place version.dll in your GTA V directory. Using FSL is now optional but highly recommended for account safety
+1. Download the latest version of FSL from [here](https://www.unknowncheats.me/forum/grand-theft-auto-v/616977-fsl-local-gtao-saves.html) and place WINMM.dll in your GTA V directory. Using FSL is now optional but highly recommended for account safety
 2. Download YimMenuV2 from [GitHub Releases](https://github.com/YimMenu/YimMenuV2/releases/tag/nightly)
 3. Download an injector, such as [Xenos](https://www.unknowncheats.me/forum/general-programming-and-reversing/124013-xenos-injector-v2-3-2-a.html)
 4. Open Rockstar Launcher, select Grand Theft Auto V Enhanced, go to settings, and disable BattlEye. If you are using Steam or Epic Games, you may have to pass the -nobattleye command line parameter as well

--- a/src/game/backend/AnticheatBypass.cpp
+++ b/src/game/backend/AnticheatBypass.cpp
@@ -12,7 +12,7 @@ namespace YimMenu
 	{
 		int num_versions = 0;
 		for (auto& module : ModuleMgr.GetModules())
-			if (module.first == "version.dll"_J)
+			if (module.first == "WINMM.dll"_J)
 				num_versions++;
 
 		return num_versions > 1;


### PR DESCRIPTION
Since there will now be FSL v2, and the .dll will no longer be called “version” but “WINMM”, here is an adjustment.