### PR TITLE
fix(superrun): use native methods to modify speed

### DIFF
--- a/src/game/features/self/SuperRun.cpp
+++ b/src/game/features/self/SuperRun.cpp
@@ -1,57 +1,43 @@
 #include "core/commands/LoopedCommand.hpp"
 #include "core/commands/FloatCommand.hpp"
-#include "core/util/Math.hpp"
 #include "game/backend/Self.hpp"
 #include "game/gta/Natives.hpp"
 
 namespace YimMenu::Features
 {
-	static FloatCommand _SuperRunRunSpeed{"superrunrunspeed", "Run Speed", "Run speed (in m/s)", 0.0f, std::nullopt, 10.0f};
-	static FloatCommand _SuperRunSprintSpeed{"superrunsprintspeed", "Sprint Speed", "Sprint speed (in m/s)", 0.0f, std::nullopt, 30.0f};
+	// not setting a max speed on purpose to avoid value slider showing up
+	// maybe bring this up as an issue and fix?
+	static FloatCommand _SuperRunMoveRateOverride{"moverateoverride", "Move Rate Override", "Multipler for base run/sprint speed", 0.0f, std::nullopt, 2.0f};
+	static FloatCommand _SuperRunRunSprintMultiplier{"runsprintswimmultiplier", "Run/Sprint/Swim Multiplier", "Multipler with which the run/sprint/swim speed is increased with until maximum speed is reached", 1.0f, std::nullopt, 1.0f};
 
 	class SuperRun : public LoopedCommand
 	{
 		using LoopedCommand::LoopedCommand;
 
+		virtual void OnDisable() override
+		{
+			if (auto player = Self::GetPlayer())
+			{
+				auto playerId = player.GetId();
+				PLAYER::SET_SWIM_MULTIPLIER_FOR_PLAYER(playerId, 1.0f);
+				PLAYER::SET_RUN_SPRINT_MULTIPLIER_FOR_PLAYER(playerId, 1.0f);
+			}
+		}
+
+		virtual void OnEnable() override
+		{
+			if (auto player = Self::GetPlayer())
+			{
+				auto playerId = player.GetId();
+				PLAYER::SET_SWIM_MULTIPLIER_FOR_PLAYER(playerId, _SuperRunRunSprintMultiplier.GetState());
+				PLAYER::SET_RUN_SPRINT_MULTIPLIER_FOR_PLAYER(playerId, _SuperRunRunSprintMultiplier.GetState());
+			}
+		}
+
 		virtual void OnTick() override
 		{
 			if (auto ped = Self::GetPed())
-			{
-				auto pedHandle = ped.GetHandle();
-
-				if (PED::IS_PED_RAGDOLL(pedHandle))
-					return;
-
-				// don't set speed if in 1st person camera and moving backwards due to it not working properly
-				if (ENTITY::GET_ENTITY_SPEED_VECTOR(pedHandle, 1).y < 0.0f && CAM::GET_FOLLOW_PED_CAM_VIEW_MODE() == 4)
-					return;
-
-				if (TASK::IS_PED_RUNNING(pedHandle) || TASK::IS_PED_SPRINTING(pedHandle)) {
-					const float run_speed = TASK::IS_PED_SPRINTING(pedHandle) ?
-						_SuperRunSprintSpeed.GetState() :
-						_SuperRunRunSpeed.GetState();
-
-					if (ENTITY::GET_ENTITY_SPEED(pedHandle) < run_speed) {
-						Vector3 location = ENTITY::GET_ENTITY_COORDS(pedHandle, false /*Unused*/);
-						Vector3 rot = ENTITY::GET_ENTITY_ROTATION(pedHandle, 2);
-						float yaw   = Math::DegToRad(rot.z + 90);
-	
-						Vector3 offset;
-						offset.x = location.x + (run_speed * cos(yaw));
-						offset.y = location.y + (run_speed * sin(yaw));
-						offset.z = location.z;
-	
-						float groundZ;
-						MISC::GET_GROUND_Z_FOR_3D_COORD(offset.x, offset.y, 1000.f, &groundZ, false, false);
-						if (groundZ < location.z)
-							offset.z = groundZ;
-	
-						Vector3 vel = offset - location;
-	
-						ENTITY::SET_ENTITY_VELOCITY(ped.GetHandle(), vel.x, vel.y, vel.z);
-					}
-				}
-			}
+				PED::SET_PED_MOVE_RATE_OVERRIDE(ped.GetHandle(), _SuperRunMoveRateOverride.GetState());
 		}
 	};
 

--- a/src/game/frontend/submenus/Self.cpp
+++ b/src/game/frontend/submenus/Self.cpp
@@ -48,8 +48,8 @@ namespace YimMenu::Submenus
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("standonvehicles"_J));
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("disableactionmode"_J));
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("superrun"_J));
-		movementGroup->AddItem(std::make_shared<ConditionalItem>("superrun"_J, std::make_shared<FloatCommandItem>("superrunrunspeed"_J)));
-		movementGroup->AddItem(std::make_shared<ConditionalItem>("superrun"_J, std::make_shared<FloatCommandItem>("superrunsprintspeed"_J)));
+		movementGroup->AddItem(std::make_shared<ConditionalItem>("superrun"_J, std::make_shared<FloatCommandItem>("moverateoverride"_J)));
+		movementGroup->AddItem(std::make_shared<ConditionalItem>("superrun"_J, std::make_shared<FloatCommandItem>("runsprintswimmultiplier"_J)));
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("superjump"_J));
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("noclip"_J));
 		movementGroup->AddItem(std::make_shared<ConditionalItem>("noclip"_J, std::make_shared<FloatCommandItem>("noclipspeed"_J)));

--- a/src/game/frontend/submenus/Vehicle/SavedVehicles.cpp
+++ b/src/game/frontend/submenus/Vehicle/SavedVehicles.cpp
@@ -2,7 +2,7 @@
 
 #include "core/backend/FiberPool.hpp"
 #include "core/frontend/Notifications.hpp"
-#include "core/util/Strings.hpp"
+#include "core/util/strings.hpp"
 #include "game/backend/Self.hpp"
 #include "game/backend/SavedVehicles.hpp"
 #include "game/gta/Vehicle.hpp"


### PR DESCRIPTION
* Modify speed using the [`SET_PED_MOVE_RATE_OVERRIDE`](https://docs.fivem.net/natives/?_0x085BF80FA50A39D1) native method instead of calculating speed manually and setting it. This essentially is a multiplier to the base speed. This fixes backwards movement in first-person mode and while using stairs compared to previous.
* Modify run / sprint & swim speed multiplier using [`SET_SWIM_MULTIPLIER_FOR_PLAYER`](https://docs.fivem.net/natives/?_0xA91C6F0FF7D16A13) & [`SET_RUN_SPRINT_MULTIPLIER_FOR_PLAYER`](https://docs.fivem.net/natives/?_0x6DB47AA77FD94E09) native methods respectively.