### PR TITLE
feat(ui): allow configuration of slider for int/float command items

### DIFF
--- a/src/game/features/self/SuperRun.cpp
+++ b/src/game/features/self/SuperRun.cpp
@@ -5,10 +5,8 @@
 
 namespace YimMenu::Features
 {
-	// not setting a max speed on purpose to avoid value slider showing up
-	// maybe bring this up as an issue and fix?
-	static FloatCommand _SuperRunMoveRateOverride{"moverateoverride", "Move Rate Override", "Multipler for base run/sprint speed", 0.0f, std::nullopt, 2.0f};
-	static FloatCommand _SuperRunRunSprintMultiplier{"runsprintswimmultiplier", "Run/Sprint/Swim Multiplier", "Multipler with which the run/sprint/swim speed is increased with until maximum speed is reached", 1.0f, std::nullopt, 1.0f};
+	static FloatCommand _SuperRunMoveRateOverride{"moverateoverride", "Move Rate Override", "Multipler for base run/sprint speed", 0.0f, 10.0f, 2.0f};
+	static FloatCommand _SuperRunRunSprintMultiplier{"runsprintswimmultiplier", "Run/Sprint/Swim Multiplier", "Multipler with which the run/sprint/swim speed is increased with until maximum speed is reached", 1.0f, 1.49f, 1.0f};
 
 	class SuperRun : public LoopedCommand
 	{

--- a/src/game/frontend/items/FloatCommandItem.cpp
+++ b/src/game/frontend/items/FloatCommandItem.cpp
@@ -6,7 +6,8 @@
 
 namespace YimMenu
 {
-	FloatCommandItem::FloatCommandItem(joaat_t id, std::optional<std::string> label_override) :
+	FloatCommandItem::FloatCommandItem(joaat_t id, std::optional<std::string> label_override, bool use_slider) :
+	    m_useSlider(use_slider),
 	    m_Command(Commands::GetCommand<FloatCommand>(id)),
 	    m_LabelOverride(label_override)
 	{
@@ -20,9 +21,9 @@ namespace YimMenu
 			return;
 		}
 
-		auto value  = m_Command->GetState();
+		auto value = m_Command->GetState();
 		auto label = m_LabelOverride.has_value() ? m_LabelOverride.value().c_str() : m_Command->GetLabel().c_str();
-		if (!m_Command->GetMinimum().has_value() || !m_Command->GetMaximum().has_value())
+		if (!m_Command->GetMinimum().has_value() || !m_Command->GetMaximum().has_value() || !m_useSlider)
 		{
 			ImGui::SetNextItemWidth(150);
 			if (ImGui::InputFloat(label, &value))

--- a/src/game/frontend/items/IntCommandItem.cpp
+++ b/src/game/frontend/items/IntCommandItem.cpp
@@ -6,7 +6,8 @@
 
 namespace YimMenu
 {
-	IntCommandItem::IntCommandItem(joaat_t id, std::optional<std::string> label_override) :
+	IntCommandItem::IntCommandItem(joaat_t id, std::optional<std::string> label_override, bool use_slider) :
+	    m_useSlider(use_slider),
 	    m_Command(Commands::GetCommand<IntCommand>(id)),
 	    m_LabelOverride(label_override)
 	{
@@ -20,9 +21,9 @@ namespace YimMenu
 			return;
 		}
 
-		int value = m_Command->GetState();
+		int value  = m_Command->GetState();
 		auto label = m_LabelOverride.has_value() ? m_LabelOverride.value().c_str() : m_Command->GetLabel().c_str();
-		if (!m_Command->GetMinimum().has_value() || !m_Command->GetMaximum().has_value())
+		if (!m_Command->GetMinimum().has_value() || !m_Command->GetMaximum().has_value() || !m_useSlider)
 		{
 			ImGui::SetNextItemWidth(150);
 			if (ImGui::InputInt(label, &value))

--- a/src/game/frontend/items/Items.hpp
+++ b/src/game/frontend/items/Items.hpp
@@ -64,10 +64,11 @@ namespace YimMenu
 	class IntCommandItem : public UIItem
 	{
 	public:
-		explicit IntCommandItem(joaat_t id, std::optional<std::string> label_override = std::nullopt);
+		explicit IntCommandItem(joaat_t id, std::optional<std::string> label_override = std::nullopt, bool use_slider = true);
 		void Draw() override;
 
 	private:
+		bool m_useSlider;
 		IntCommand* m_Command;
 		std::optional<std::string> m_LabelOverride;
 	};
@@ -75,10 +76,11 @@ namespace YimMenu
 	class FloatCommandItem : public UIItem
 	{
 	public:
-		explicit FloatCommandItem(joaat_t id, std::optional<std::string> label_override = std::nullopt);
+		explicit FloatCommandItem(joaat_t id, std::optional<std::string> label_override = std::nullopt, bool use_slider = true);
 		void Draw() override;
 
 	private:
+		bool m_useSlider;
 		FloatCommand* m_Command;
 		std::optional<std::string> m_LabelOverride;
 	};

--- a/src/game/frontend/submenus/Self.cpp
+++ b/src/game/frontend/submenus/Self.cpp
@@ -48,8 +48,8 @@ namespace YimMenu::Submenus
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("standonvehicles"_J));
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("disableactionmode"_J));
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("superrun"_J));
-		movementGroup->AddItem(std::make_shared<ConditionalItem>("superrun"_J, std::make_shared<FloatCommandItem>("moverateoverride"_J)));
-		movementGroup->AddItem(std::make_shared<ConditionalItem>("superrun"_J, std::make_shared<FloatCommandItem>("runsprintswimmultiplier"_J)));
+		movementGroup->AddItem(std::make_shared<ConditionalItem>("superrun"_J, std::make_shared<FloatCommandItem>("moverateoverride"_J, std::nullopt, false)));
+		movementGroup->AddItem(std::make_shared<ConditionalItem>("superrun"_J, std::make_shared<FloatCommandItem>("runsprintswimmultiplier"_J, std::nullopt, false)));
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("superjump"_J));
 		movementGroup->AddItem(std::make_shared<BoolCommandItem>("noclip"_J));
 		movementGroup->AddItem(std::make_shared<ConditionalItem>("noclip"_J, std::make_shared<FloatCommandItem>("noclipspeed"_J)));


### PR DESCRIPTION
See https://github.com/YimMenu/YimMenuV2/pull/400#issuecomment-2957788866 for more information.

This will keep all existing slider as is, only will explicitly disable it when `use_slider` argument to `false`.