### PR TITLE
Add duplicate checkbox to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -78,3 +78,10 @@ body:
       options:
         - label: I've confirmed the issue exists on the latest version of YimMenuV2
           required: true
+  - type: checkboxes
+    attributes:
+      label: Duplicate
+      description: You confirm that you've read existing open issues of YimMenuV2 and this isn't a duplicate of an already existing bug.
+      options:
+        - label: I confirm that issue isn't a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -33,3 +33,10 @@ body:
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false
+  - type: checkboxes
+    attributes:
+      label: Duplicate
+      description: You confirm that you've read existing open issues of YimMenuV2 and this isn't an existing feature request.
+      options:
+        - label: I confirm that issue isn't a duplicate.
+          required: true


### PR DESCRIPTION
Add a checkbox to the issue template in the hopes that users spend at least a few more seconds verifying if their issue is a duplicate or not.