### PR TITLE
deps: Update AsyncLogger

### DIFF
--- a/cmake/async-logger.cmake
+++ b/cmake/async-logger.cmake
@@ -4,7 +4,7 @@ message(STATUS "Setting up AsyncLogger")
 FetchContent_Declare(
     AsyncLogger
     GIT_REPOSITORY https://github.com/Yimura/AsyncLogger.git
-    GIT_TAG 6fcfd90b3f4ca4dae09c4a96e9a506e6aea06472
+    GIT_TAG 25b5ed31b33c40fabc6b80213c330a10cccf3b49
     GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(AsyncLogger)


### PR DESCRIPTION
[fix: no type named 'thread' in namespace 'std'](https://github.com/Yimura/AsyncLogger/commit/25b5ed31b33c40fabc6b80213c330a10cccf3b49)
[fix: unable to properly set USE_FMT](https://github.com/Yimura/AsyncLogger/commit/1137fde556c7c0a91d87256118b9f286b0d67a38)

First one was preventing building on some compilers (those one without implicit/force includes)