### PR TITLE
fix: outdated toolchain in cross-compile CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
 
   cross-compilation:
     runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
     name: Cross-compilation
     strategy:
       matrix:
@@ -51,18 +53,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup CMake and build tools
+        run: |
+          apk update
+          apk add --no-cache build-base git cmake ninja
+          cmake --version
+
       - name: Setup Zig
         if: matrix.compiler == 'Zig'
-        uses: mlugg/setup-zig@v2
+        run: |
+          apk add --no-cache zig
+          echo "Zig version: $(zig version)"
 
-      - name: Setup MinGW
+      - name: Setup Clang with MinGW
         if: matrix.compiler == 'Clang'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang lld binutils-mingw-w64-x86-64 mingw-w64-x86-64-dev gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
-
-      - name: Check CMake version
-        run: cmake --version
+          apk add --no-cache clang lld mingw-w64-binutils mingw-w64-crt mingw-w64-headers mingw-w64-gcc mingw-w64-winpthreads
+          clang --version
 
       - name: Generate CMake project
         run: cmake -DUSE_CROSSCOMPILER=${{ matrix.compiler }} -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build -G Ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,35 +44,20 @@ jobs:
 
   cross-compilation:
     runs-on: ubuntu-latest
-    container:
-      image: alpine:latest
     name: Cross-compilation
-    strategy:
-      matrix:
-        compiler: ["Zig", "Clang"]
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup CMake and build tools
         run: |
-          apk update
-          apk add --no-cache build-base git cmake ninja
-          cmake --version
+          sudo apt update
+          sudo apt install -y cmake ninja-build
 
       - name: Setup Zig
-        if: matrix.compiler == 'Zig'
-        run: |
-          apk add --no-cache zig
-          echo "Zig version: $(zig version)"
-
-      - name: Setup Clang with MinGW
-        if: matrix.compiler == 'Clang'
-        run: |
-          apk add --no-cache clang lld mingw-w64-binutils mingw-w64-crt mingw-w64-headers mingw-w64-gcc mingw-w64-winpthreads
-          clang --version
+        uses: mlugg/setup-zig@v2
 
       - name: Generate CMake project
-        run: cmake -DUSE_CROSSCOMPILER=${{ matrix.compiler }} -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build -G Ninja
+        run: cmake -DUSE_CROSSCOMPILER=Zig -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build -G Ninja
 
       - name: Build 64bit RelWithDebInfo DLL
         run: cmake --build ./build --config RelWithDebInfo --target YimMenuV2 --
@@ -83,13 +68,13 @@ jobs:
       - name: Rename DLL to libYimMenuV2-dev-{GITHUB_SHA}.dll
         run: |
           mv libYimMenuV2.dll libYimMenuV2-dev-${{github.sha}}.dll
-          mv libYimMenuV2.pdb libYimMenuV2-dev-${{github.sha}}.pdb || true
+          mv libYimMenuV2.pdb libYimMenuV2-dev-${{github.sha}}.pdb
         working-directory: build/
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: RelWithDebInfo-Cross-${{ matrix.compiler }}
+          name: RelWithDebInfo-Cross
           path: |
             build/libYimMenuV2-dev-*.dll
             build/libYimMenuV2-dev-*.pdb


### PR DESCRIPTION
Closes: #554

Now it simply runs in Alpine image which has even newer toolchain then I do on my OS

The only disadvantage is, that it takes longer to build

Here's results: https://github.com/playday3008/YimMenuV2/actions/runs/15869471765