### PR TITLE
fix: broken logging under Wine

### DIFF
--- a/src/core/logger/LogSink.cpp
+++ b/src/core/logger/LogSink.cpp
@@ -4,6 +4,8 @@
 
 #include <format>
 
+#include "core/util/Wine.hpp"
+
 namespace YimMenu
 {
 	LogColor LogSink::GetColor(const eLogLevel level)
@@ -28,6 +30,12 @@ namespace YimMenu
 	std::string LogSink::FormatConsole(const LogMessagePtr msg)
 	{
 		std::stringstream out;
+
+		static std::optional<bool> simplified = std::nullopt;
+		if (!simplified.has_value())
+			simplified = InWine();
+		if (simplified.value_or(false))
+			return FormatFile(msg);
 
 		const auto timestamp = std::format("{0:%H:%M:%S}", msg->Timestamp());
 		const auto& location = msg->Location();

--- a/src/core/util/Wine.hpp
+++ b/src/core/util/Wine.hpp
@@ -9,6 +9,6 @@ namespace YimMenu {
         auto module = ModuleMgr.Get("ntdll.dll"_J);
         if (!module)
             return std::nullopt;
-        return module->GetExport("wine_get_version");
+        return module->IsExported("wine_get_version");
     }
 }

--- a/src/core/util/Wine.hpp
+++ b/src/core/util/Wine.hpp
@@ -1,0 +1,14 @@
+#include "core/memory/ModuleMgr.hpp"
+#include "Joaat.hpp"
+
+#include <optional>
+
+namespace YimMenu {
+    inline std::optional<bool> InWine()
+    {
+        auto module = ModuleMgr.Get("ntdll.dll"_J);
+        if (!module)
+            return std::nullopt;
+        return module->GetExport("wine_get_version");
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "core/hooking/CallHook.hpp"
 #include "core/memory/ModuleMgr.hpp"
 #include "core/renderer/Renderer.hpp"
+#include "core/util/Wine.hpp"
 #include "core/scripting/LuaManager.hpp"
 #include "game/backend/AnticheatBypass.hpp"
 #include "game/backend/Players.hpp"
@@ -83,6 +84,9 @@ namespace YimMenu
 			LOG(WARNING) << "Socialclub patterns failed to load";
 
 		Notifications::Show("YimMenuV2", "Loaded succesfully", NotificationType::Success);
+
+		if (InWine().value_or(false))
+		    LOG(INFO) << "Running in Wine!";
 
 		while (g_Running)
 		{


### PR DESCRIPTION
The problem only is: on Windows it will log a `FATAL` error as it will not find a `wine_get_version` export in `ntdll`, but that's just log:
https://github.com/YimMenu/YimMenuV2/blob/b3d741ca512885d75b83d53f1b5429fc4e012b71/src/core/memory/Module.hpp#L86
https://github.com/YimMenu/YimMenuV2/blob/b3d741ca512885d75b83d53f1b5429fc4e012b71/src/core/memory/Module.hpp#L110
I think this log statement should be removed, or wrap it, so there will be two functions, one `GetExportLoosy` (for example) without log statement, and `GetExport` which will be wrapper around `GetExportLoosy` with log statement. Or create something like `IsExported`, `GetExportImpl`, `GetExport` (here log will be)