### PR TITLE
refractor savedvehicles & vehicle spawn

### DIFF
--- a/src/game/backend/SavedVehicles.hpp
+++ b/src/game/backend/SavedVehicles.hpp
@@ -11,12 +11,12 @@ namespace YimMenu
 
 		static void RefreshList(std::string folderName, std::vector<std::string>& folders, std::vector<std::string>& files);
 		static void Save(std::string folderName, std::string fileName);
-		static void Load(std::string folderName, std::string fileName);
+		static void Load(std::string folderName, std::string fileName, bool spawnInside);
 
 	private:
 		static nlohmann::json GetJson(Vehicle vehicle);
 		static Folder CheckFolder(std::string folderName = "");
-		static bool SpawnFromJson(nlohmann::json);
+		static Vehicle SpawnFromJson(nlohmann::json);
 
 	private:
 		static constexpr auto plate_text_key = "plate_text";

--- a/src/game/frontend/submenus/Vehicle/SavedVehicles.cpp
+++ b/src/game/frontend/submenus/Vehicle/SavedVehicles.cpp
@@ -1,5 +1,5 @@
 #include "SavedVehicles.hpp"
-
+#include "core/commands/BoolCommand.hpp"
 #include "core/backend/FiberPool.hpp"
 #include "core/backend/ScriptMgr.hpp"
 #include "core/frontend/Notifications.hpp"
@@ -11,6 +11,8 @@
 
 namespace YimMenu::Submenus
 {
+	static BoolCommand spawnInsideSavedVehicle{"spawninsidesavedveh", "Spawn Inside", "Spawn inside the vehicle."};
+
 	std::shared_ptr<Category> BuildSavedVehiclesMenu()
 	{
 		static std::string folder{}, file{};
@@ -19,6 +21,8 @@ namespace YimMenu::Submenus
 		static char newFolder[50]{};
 
 		auto persistCar = std::make_shared<Category>("Saved Vehicles");
+
+		persistCar->AddItem(std::make_shared<BoolCommandItem>("spawninsidesavedveh"_J));
 
 		persistCar->AddItem(std::make_unique<ImGuiItem>([] {
 			static auto drawSaveVehicleButton = [](bool saveToNewFolder) {
@@ -140,7 +144,7 @@ namespace YimMenu::Submenus
 				ImGui::Spacing();
 				if (ImGui::Button("Yes"))
 				{
-					SavedVehicles::Load(folder, file);
+					SavedVehicles::Load(folder, file, spawnInsideSavedVehicle.GetState());		
 					open_modal = false;
 					ImGui::CloseCurrentPopup();
 				}

--- a/src/game/frontend/submenus/Vehicle/SpawnVehicle.cpp
+++ b/src/game/frontend/submenus/Vehicle/SpawnVehicle.cpp
@@ -15,25 +15,6 @@ namespace YimMenu::Submenus
 	static BoolCommand spawnInsidePersonalVehicle{"spawninsidepv", "Spawn Inside", "Spawn inside the personal vehicle."};
 	static BoolCommand spawnClonePersonalVehicle{"spawnclonepv", "Spawn Clone", "Spawn a clone of the persone vehicle."};
 
-	static Vector3 GetVehicleSpawnLoc(joaat_t hash, bool spawnInside)
-	{
-		float y_offset = 0;
-
-		if (Self::GetVehicle().IsValid())
-		{
-			Vector3 min, max, result;
-			MISC::GET_MODEL_DIMENSIONS(hash, &min, &max);
-			result = max - min;
-			y_offset = result.y;
-		}
-		else if (!spawnInside)
-		{
-			y_offset = 5.f;
-		}
-
-		return ENTITY::GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS(Self::GetPed().GetHandle(), 0.f, y_offset, 0.f);
-	}
-
 	std::shared_ptr<TabItem> RenderSpawnNewVehicle()
 	{
 		auto tab = std::make_shared<TabItem>("New Vehicle");
@@ -129,7 +110,7 @@ namespace YimMenu::Submenus
 							if (ImGui::Selectable(name.c_str()))
 							{
 								FiberPool::Push([hash] {
-									auto handle = Vehicle::Create(hash, GetVehicleSpawnLoc(hash, spawnInsideVehicle.GetState()), Self::GetPed().GetHeading());
+									auto handle = Vehicle::Create(hash, Vehicle::GetSpawnLocRelToPed(Self::GetPed().GetHandle(), hash), Self::GetPed().GetHeading());
 
 									if (spawnInsideVehicle.GetState())
 										Self::GetPed().SetInVehicle(handle);
@@ -222,7 +203,7 @@ namespace YimMenu::Submenus
 								FiberPool::Push([&personalVeh] {
 									if (spawnClonePersonalVehicle.GetState())
 									{
-										auto coords  = GetVehicleSpawnLoc(personalVeh->GetModel(), spawnInsidePersonalVehicle.GetState());
+										auto coords  = Vehicle::GetSpawnLocRelToPed(Self::GetPed().GetHandle(), personalVeh->GetModel());
 										auto heading = Self::GetPed().GetHeading();
 										auto handle  = personalVeh->Clone(coords, heading);
 										

--- a/src/game/gta/Vehicle.cpp
+++ b/src/game/gta/Vehicle.cpp
@@ -274,4 +274,11 @@ namespace YimMenu
 
 		return ownedMods;
 	}
+
+	Vector3 Vehicle::GetSpawnLocRelToPed(int ped, joaat_t hash)
+	{
+		Vector3 min, max;
+		MISC::GET_MODEL_DIMENSIONS(hash, &min, &max);
+		return ENTITY::GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS(ped, 0.f, (max - min).y, 0.f);
+	}
 }

--- a/src/game/gta/Vehicle.hpp
+++ b/src/game/gta/Vehicle.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include "Entity.hpp"
+#include "types/script/types.hpp"
+#include "core/util/Joaat.hpp"
 
 namespace YimMenu
 {
@@ -10,14 +12,16 @@ namespace YimMenu
 
 		static Vehicle Create(std::uint32_t model, rage::fvector3 coords, float heading = 0.0f);
 
+		// health
 		void Fix();
 
 		// gears
 		int GetGear();
 		float GetRevRatio();
 
-		// speed
+		// motion
 		float GetMaxSpeed();
+		void BringToHalt(float distance = 1.0f, int duration = 1);
 
 		// mods
 		void Upgrade();
@@ -36,9 +40,11 @@ namespace YimMenu
 		// stance
 		void LowerStance(bool lower);
 
-		void BringToHalt(float distance = 1.0f, int duration = 1);
+		// position
 		bool SetOnGroundProperly();
+		static Vector3 GetSpawnLocRelToPed(int ped, joaat_t hash);
 
+		// description
 		std::string GetFullName();
 	};
 }


### PR DESCRIPTION
closes closes https://github.com/YimMenu/YimMenuV2/issues/602

- add checkbox in saved vehicles to spawninside
- use shared logic to get spawn location for a given vehicle model of a saved veh, cloned pv veh or a spawn veh

what to test:
- check if vehicle spawns correctly in front of player when spawning a simple vehicle, cloned pv or a saved vehicle.
- check if newly added spawn inside checkbox in saved vehicles is working correctly.