### PR TITLE
fix(casino): Fix game freeze when disable Manipulate Rig Slot Machines 

### DIFF
--- a/src/game/features/recovery/Casino.cpp
+++ b/src/game/features/recovery/Casino.cpp
@@ -5,6 +5,7 @@
 #include "game/gta/Stats.hpp"
 #include "core/commands/ListCommand.hpp"
 #include "game/backend/Tunables.hpp"
+#include "core/backend/ScriptMgr.hpp"
 
 #include <set>
 
@@ -18,6 +19,7 @@ namespace YimMenu::Features
 		int slots_random_results_table = 1350;
 		std::set<int> slots_blacklist = {9, 21, 22, 87, 152};
 		int spin_state_var = 1668;
+		std::set<int> spin_state_whitelist = {8, 14};
 
 		virtual void OnTick() override
 		{
@@ -41,14 +43,15 @@ namespace YimMenu::Features
 						if (*ScriptLocal("casino_slots"_J, slots_random_results_table + slots_iter).As<int*>() != 6)
 						{
 							needs_run = true;
+							break;
 						}
 					}
 				}
-				if (needs_run && *spin_state >= 8 && *spin_state <= 15)
+				if (needs_run)
 				{
 					for (int slots_iter = 3; slots_iter <= 196; ++slots_iter)
 					{
-						if (!slots_blacklist.contains(slots_iter))
+						if (!slots_blacklist.contains(slots_iter) && spin_state_whitelist.contains(*spin_state))
 						{
 							int slot_result = 6;
 							*ScriptLocal("casino_slots"_J, slots_random_results_table + slots_iter).As<int*>() = slot_result;
@@ -58,7 +61,7 @@ namespace YimMenu::Features
 			}
 		}
 
-		virtual void OnDisable() override
+virtual void OnDisable() override
 		{
 			if (Scripts::SafeToModifyFreemodeBroadcastGlobals() && SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH("casino_slots"_J))
 			{
@@ -70,13 +73,26 @@ namespace YimMenu::Features
 					Scripts::ForceScriptHost(Scripts::FindScriptThread("casino_slots"_J));
 				}
 
+				int* spin_state = ScriptLocal("casino_slots"_J, spin_state_var).As<int*>();
+				// waiting for reset until next time using
+				while (!spin_state_whitelist.contains(*spin_state))
+				{
+					ScriptMgr::Yield();
+					spin_state = ScriptLocal("casino_slots"_J, spin_state_var).As<int*>();
+				}
+				casinoSlotsScriptHostPlayer = NETWORK::NETWORK_GET_HOST_OF_SCRIPT("casino_slots", -1, 0);
+				casinoSlotsScriptHostPlayerId = casinoSlotsScriptHostPlayer.GetId();
+				if (casinoSlotsScriptHostPlayerId != selfPlayerId)
+				{
+					Scripts::ForceScriptHost(Scripts::FindScriptThread("casino_slots"_J));
+				}
 				for (int slots_iter = 3; slots_iter <= 196; ++slots_iter)
 				{
 					if (!slots_blacklist.contains(slots_iter))
 					{
 						int slot_result = 6;
 						std::srand(static_cast<unsigned int>(std::time(0)) + slots_iter);
-						slot_result = std::rand() % 7; // Generates a pseudo random number between 0 and 7
+						slot_result = 3 + std ::rand() % 7; // Generates a pseudo random number [3,9] 
 						*ScriptLocal("casino_slots"_J, slots_random_results_table + slots_iter).As<int*>() = slot_result;
 					}
 				}

--- a/src/game/features/recovery/Casino.cpp
+++ b/src/game/features/recovery/Casino.cpp
@@ -44,11 +44,11 @@ namespace YimMenu::Features
 						}
 					}
 				}
-				if (needs_run && *spin_state >= 8 && *spin_state <= 15)
+				if (needs_run)
 				{
 					for (int slots_iter = 3; slots_iter <= 196; ++slots_iter)
 					{
-						if (!slots_blacklist.contains(slots_iter))
+						if (!slots_blacklist.contains(slots_iter) && *spin_state >= 8 && *spin_state <= 15)
 						{
 							int slot_result = 6;
 							*ScriptLocal("casino_slots"_J, slots_random_results_table + slots_iter).As<int*>() = slot_result;
@@ -69,10 +69,10 @@ namespace YimMenu::Features
 				{
 					Scripts::ForceScriptHost(Scripts::FindScriptThread("casino_slots"_J));
 				}
-
+				int* spin_state = ScriptLocal("casino_slots"_J, spin_state_var).As<int*>();
 				for (int slots_iter = 3; slots_iter <= 196; ++slots_iter)
 				{
-					if (!slots_blacklist.contains(slots_iter))
+					if (!slots_blacklist.contains(slots_iter) && *spin_state >= 8 && *spin_state <= 15)
 					{
 						int slot_result = 6;
 						std::srand(static_cast<unsigned int>(std::time(0)) + slots_iter);

--- a/src/game/features/recovery/Casino.cpp
+++ b/src/game/features/recovery/Casino.cpp
@@ -79,13 +79,11 @@ virtual void OnDisable() override
 				{
 					ScriptMgr::Yield();
 					spin_state = ScriptLocal("casino_slots"_J, spin_state_var).As<int*>();
+					if (spin_state == nullptr){
+						return;
+					}
 				}
-				casinoSlotsScriptHostPlayer = NETWORK::NETWORK_GET_HOST_OF_SCRIPT("casino_slots", -1, 0);
-				casinoSlotsScriptHostPlayerId = casinoSlotsScriptHostPlayer.GetId();
-				if (casinoSlotsScriptHostPlayerId != selfPlayerId)
-				{
-					Scripts::ForceScriptHost(Scripts::FindScriptThread("casino_slots"_J));
-				}
+
 				for (int slots_iter = 3; slots_iter <= 196; ++slots_iter)
 				{
 					if (!slots_blacklist.contains(slots_iter))

--- a/src/game/features/recovery/Casino.cpp
+++ b/src/game/features/recovery/Casino.cpp
@@ -44,11 +44,11 @@ namespace YimMenu::Features
 						}
 					}
 				}
-				if (needs_run)
+				if (needs_run && *spin_state >= 8 && *spin_state <= 15)
 				{
 					for (int slots_iter = 3; slots_iter <= 196; ++slots_iter)
 					{
-						if (!slots_blacklist.contains(slots_iter) && *spin_state >= 8 && *spin_state <= 15)
+						if (!slots_blacklist.contains(slots_iter))
 						{
 							int slot_result = 6;
 							*ScriptLocal("casino_slots"_J, slots_random_results_table + slots_iter).As<int*>() = slot_result;
@@ -69,10 +69,10 @@ namespace YimMenu::Features
 				{
 					Scripts::ForceScriptHost(Scripts::FindScriptThread("casino_slots"_J));
 				}
-				int* spin_state = ScriptLocal("casino_slots"_J, spin_state_var).As<int*>();
+
 				for (int slots_iter = 3; slots_iter <= 196; ++slots_iter)
 				{
-					if (!slots_blacklist.contains(slots_iter) && *spin_state >= 8 && *spin_state <= 15)
+					if (!slots_blacklist.contains(slots_iter))
 					{
 						int slot_result = 6;
 						std::srand(static_cast<unsigned int>(std::time(0)) + slots_iter);


### PR DESCRIPTION
now we must ensure result [3,9]
also we should ensure we are write slots_random_results_table at a "safe period", nomatter enable or reset while disable.

fix issue https://github.com/YimMenu/YimMenuV2/issues/791