### PR TITLE
fix(pointers): update patterns after last update

### DIFF
--- a/src/game/pointers/Pointers.cpp
+++ b/src/game/pointers/Pointers.cpp
@@ -107,7 +107,7 @@ namespace YimMenu
 			ScriptGlobals = ptr.Add(7).Add(3).Rip().As<std::int64_t**>();
 		});
 
-		constexpr auto sendNetworkDamagePtrn = Pattern<"0F B6 41 28 04 FE 3C 03 0F 87 EA">("SendNetworkDamage");
+		constexpr auto sendNetworkDamagePtrn = Pattern<"0F B6 41 28 04 FE 3C 03 0F 87 ? ? ? ? 48 83 BF D0 00 00 00 00">("SendNetworkDamage");
 		scanner.Add(sendNetworkDamagePtrn, [this](PointerCalculator ptr) {
 			TriggerWeaponDamageEvent = ptr.Sub(0x51).As<Functions::TriggerWeaponDamageEvent>();
 		});
@@ -199,10 +199,11 @@ namespace YimMenu
 			NetEventMgr = ptr.Add(3).Rip().As<rage::netEventMgr**>();
 		});
 
-		constexpr auto sendEventAckPtrn = Pattern<"84 C0 75 ? 89 EE 49 8D AD">("SendEventAck");
+		constexpr auto sendEventAckPtrn = Pattern<"84 C0 75 ? 89 EE 89 F0 48 83 C4">("SendEventAck");
 		scanner.Add(sendEventAckPtrn, [this](PointerCalculator ptr) {
-			EventAck = ptr.Sub(4).Rip().As<Functions::EventAck>();
-			SendEventAck = ptr.Add(0x13).Add(1).Rip().As<Functions::SendEventAck>();
+			SendEventAck = ptr.Sub(0x174).As<Functions::SendEventAck>();
+			// EventAck was a relative call above this site; it's call rbx now
+			EventAck = nullptr;
 		});
 
 		constexpr auto queueDependencyPtrn = Pattern<"0F 29 46 50 48 8D 05">("QueueDependency&SigScanMemory");
@@ -216,9 +217,9 @@ namespace YimMenu
 			ScriptVM = ptr.Sub(0x24).As<Functions::ScriptVM>();
 		});
 
-		constexpr auto prepareMetricForSendingPtrn = Pattern<"48 89 F9 FF 50 20 48 8D 15">("PrepareMetricForSending");
+		constexpr auto prepareMetricForSendingPtrn = Pattern<"48 89 F1 FF 50 20 48 8D 15 ? ? ? ? 48 89 F9 49 89 C0">("PrepareMetricForSending");
 		scanner.Add(prepareMetricForSendingPtrn, [this](PointerCalculator ptr) {
-			PrepareMetricForSending = ptr.Sub(0x26).As<PVOID>();
+			PrepareMetricForSending = ptr.Sub(0x4B).As<PVOID>();
 		});
 
 		constexpr auto beDataPtrn = Pattern<"48 C7 05 ? ? ? ? 00 00 00 00 E8 ? ? ? ? 48 89 C1 E8 ? ? ? ? E8 ? ? ? ? BD 0A 00 00 00">("BEData");
@@ -230,16 +231,14 @@ namespace YimMenu
 
 		constexpr auto battlEyeStatusUpdatePatchPtrn = Pattern<"80 B9 92 0A 00 00 01">("BattlEyeStatusUpdatePatch");
 		scanner.Add(battlEyeStatusUpdatePatchPtrn, [this](PointerCalculator ptr) {
-			BattlEyeStatusUpdatePatch = BytePatches::Add(ptr.As<void*>(), 
-				// since arxan obfuscated this subroutine, return mid-function instead
-				// TODO: this might break in a later update
-				std::to_array<std::uint8_t>({
-					0x48, 0x83, 0xC4, 0x38, // add rsp, 38h
-					0x5F,                   // pop rdi
-					0x5E,                   // pop rsi
-					0xC3                    // ret
-				})
-			);
+			// pattern still hits the arxan mid-site, but early-ret there crashes now.
+			// real entry is +0x10C (push rbp / sub rsp, 0xA0), just ret out of the call.
+			auto entry = ptr.Add(0x10C).As<std::uint8_t*>();
+			if (entry && entry[0] == 0x55 && entry[1] == 0x48 && entry[2] == 0x81)
+			{
+				BattlEyeStatusUpdatePatch = BytePatches::Add(entry,
+					std::to_array<std::uint8_t>({0x31, 0xC0, 0xC3})); // xor eax, eax; ret
+			}
 		});
 
 		constexpr auto writeNetArrayDataPtrn = Pattern<"0F 84 06 03 00 00 0F B6 83">("WriteNetArrayData");
@@ -370,7 +369,7 @@ namespace YimMenu
 			SetJoinRequestPoolTypePatch = BytePatches::Add(ptr.Sub(5).As<std::uint8_t*>(), std::to_array<std::uint8_t>({0xB8, 0x00, 0x00, 0x00, 0x00}));
 		});
 
-		constexpr auto handleJoinRequestIgnorePoolPatchPtrn = Pattern<"41 83 FF 05 74 ? 42 8B 84 F5">("HandleJoinRequestIgnorePoolPatch");
+		constexpr auto handleJoinRequestIgnorePoolPatchPtrn = Pattern<"41 83 FF 05 74 ? 41 83 FF 01">("HandleJoinRequestIgnorePoolPatch");
 		scanner.Add(handleJoinRequestIgnorePoolPatchPtrn, [this](PointerCalculator ptr) {
 			HandleJoinRequestIgnorePoolPatch = BytePatches::Add(ptr.As<void*>(), std::to_array<std::uint8_t>({0x39, 0xC9, 0x90, 0x90}));
 		});


### PR DESCRIPTION
Refreshes a few Enhanced signatures that broke on the latest game update.

### Changes
- **SendNetworkDamage** — jnbe is a near jcc now, kept `Sub(0x51)`
- **PrepareMetricForSending** — `F9` -> `F1`, entry delta `0x26` -> `0x4B`
- **SendEventAck** — new epilogue pattern; helper entry is `Sub(0x174)`. EventAck used to be a relative call above the hit and is `call rbx` now, so it's left null for now
- **BattlEyeStatusUpdatePatch** — mid-function early-ret crashes under current arxan, so we ret at the real call entry (`island+0x10C`) after a quick prolog check
- **HandleJoinRequestIgnorePoolPatch** — old SIB tail is gone, new unique follow-up is `41 83 FF 01` (patch bytes unchanged)

### Not covered
- **JoinSessionByInfo** still needs a clean signature (old one is fully dead / only arxan fragments left)

### Test plan
- [ ] Inject on latest Enhanced, confirm the updated patterns resolve
- [ ] Session / metric path doesn't crash
- [ ] BE status patch applies without NX
- [ ] Pool ignore patch still behaves
