### PR TITLE
feat(vehicle): add autodrive functionality

### DIFF
--- a/src/game/features/vehicle/AutoDrive.cpp
+++ b/src/game/features/vehicle/AutoDrive.cpp
@@ -1,0 +1,175 @@
+#include "AutoDriveShared.hpp"
+
+#include "core/commands/BoolCommand.hpp"
+#include "core/commands/Commands.hpp"
+#include "core/commands/LoopedCommand.hpp"
+#include "core/frontend/Notifications.hpp"
+#include "game/backend/Self.hpp"
+#include "game/gta/Natives.hpp"
+#include "types/pad/ControllerInputs.hpp"
+
+#include <cmath>
+#include <string>
+#include <string_view>
+
+namespace YimMenu::Features
+{
+	class AutoDrive : public LoopedCommand
+	{
+		enum class FailureReason
+		{
+			None,
+			NoVehicle,
+			PlayerDead,
+			NotDriver,
+			UnsupportedVehicle,
+			VehicleUndriveable,
+			NoControl
+		};
+
+		static constexpr float manual_input_deadzone = 0.2f;
+
+		AutoDriveInternal::RoadDriveController m_Route;
+		AutoDriveInternal::SessionToken m_Session;
+		FailureReason m_FailureReason = FailureReason::None;
+
+		static bool HasManualDrivingInput()
+		{
+			const auto steering = std::abs(PAD::GET_CONTROL_NORMAL(0, static_cast<int>(ControllerInputs::INPUT_VEH_MOVE_LR)));
+			const auto accelerate = std::abs(PAD::GET_CONTROL_NORMAL(0, static_cast<int>(ControllerInputs::INPUT_VEH_ACCELERATE)));
+			const auto brake = std::abs(PAD::GET_CONTROL_NORMAL(0, static_cast<int>(ControllerInputs::INPUT_VEH_BRAKE)));
+
+			return steering > manual_input_deadzone
+			    || accelerate > manual_input_deadzone
+			    || brake > manual_input_deadzone
+			    || PAD::IS_CONTROL_PRESSED(0, static_cast<int>(ControllerInputs::INPUT_VEH_HANDBRAKE))
+			    || PAD::IS_CONTROL_PRESSED(0, static_cast<int>(ControllerInputs::INPUT_VEH_EXIT));
+		}
+
+		void SetFailure(FailureReason reason, std::string_view message = {})
+		{
+			if (reason == m_FailureReason)
+				return;
+
+			m_FailureReason = reason;
+			if (reason != FailureReason::None)
+				Notifications::Show("Auto Drive", std::string(message), NotificationType::Warning);
+		}
+
+		void ClearOwnedSession()
+		{
+			m_Route.ClearTask();
+			m_FailureReason = FailureReason::None;
+		}
+
+		bool ValidateDriver(Ped driver, Vehicle vehicle)
+		{
+			if (!driver || !vehicle)
+			{
+				m_Route.ClearTask();
+				SetFailure(FailureReason::NoVehicle, "Enter the driver seat of a supported road vehicle.");
+				return false;
+			}
+
+			if (driver.IsDead())
+			{
+				m_Route.ClearTask();
+				SetFailure(FailureReason::PlayerDead, "Auto Drive is waiting for the player to respawn.");
+				return false;
+			}
+
+			if (VEHICLE::GET_PED_IN_VEHICLE_SEAT(vehicle.GetHandle(), -1, false) != driver.GetHandle())
+			{
+				m_Route.ClearTask();
+				SetFailure(FailureReason::NotDriver, "Move to the driver seat to use Auto Drive.");
+				return false;
+			}
+
+			if (!AutoDriveInternal::IsSupportedRoadVehicle(vehicle))
+			{
+				m_Route.ClearTask();
+				SetFailure(FailureReason::UnsupportedVehicle, "This vehicle type does not support Auto Drive.");
+				return false;
+			}
+
+			if (!VEHICLE::IS_VEHICLE_DRIVEABLE(vehicle.GetHandle(), false))
+			{
+				m_Route.ClearTask();
+				SetFailure(FailureReason::VehicleUndriveable, "The current vehicle cannot be driven.");
+				return false;
+			}
+
+			if (!vehicle.RequestControl(0))
+			{
+				m_Route.ClearTask();
+				SetFailure(FailureReason::NoControl, "Waiting for network control of the current vehicle.");
+				return false;
+			}
+
+			SetFailure(FailureReason::None);
+			return true;
+		}
+
+		virtual void OnEnable() override
+		{
+			auto npcAutoDrive = Commands::GetCommand<BoolCommand>("npcautodrive"_J);
+			if (AutoDriveInternal::Coordinator::GetOwner() == AutoDriveInternal::Owner::None
+			    && npcAutoDrive
+			    && npcAutoDrive->GetState())
+				npcAutoDrive->SetState(false);
+
+			m_Session = AutoDriveInternal::Coordinator::Claim(AutoDriveInternal::Owner::Player, [this] {
+				ClearOwnedSession();
+			});
+
+			if (npcAutoDrive && npcAutoDrive->GetState())
+				npcAutoDrive->SetState(false);
+		}
+
+		virtual void OnTick() override
+		{
+			if (!AutoDriveInternal::Coordinator::Owns(m_Session))
+				return;
+
+			auto driver = Self::GetPed();
+			auto vehicle = Self::GetVehicle();
+			if (!ValidateDriver(driver, vehicle))
+				return;
+
+			if (HasManualDrivingInput())
+			{
+				AutoDriveInternal::Coordinator::Release(m_Session);
+				SetState(false);
+				return;
+			}
+
+			if (m_Route.Tick(driver, vehicle, "Auto Drive started.") == AutoDriveInternal::RouteResult::DestinationReached)
+			{
+				AutoDriveInternal::Coordinator::Release(m_Session);
+				SetState(false);
+				Notifications::Show(
+				    "Auto Drive",
+				    "Destination reached. Auto Drive disabled; please take control.",
+				    NotificationType::Success);
+			}
+		}
+
+		virtual void OnDisable() override
+		{
+			// A queued disable callback may run after the command has already been re-enabled.
+			if (GetState() && IsReady())
+				return;
+
+			AutoDriveInternal::Coordinator::Release(m_Session);
+			m_FailureReason = FailureReason::None;
+		}
+
+	public:
+		using LoopedCommand::LoopedCommand;
+	};
+
+	static AutoDrive _AutoDrive{
+	    "autodrive",
+	    "Auto Drive",
+	    "Drives to your waypoint using roads, or roams when no waypoint is set"};
+}

--- a/src/game/features/vehicle/AutoDrive.cpp
+++ b/src/game/features/vehicle/AutoDrive.cpp
@@ -8,6 +8,7 @@
 #include "game/gta/Natives.hpp"
 #include "types/pad/ControllerInputs.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <string>
 #include <string_view>
@@ -27,23 +28,50 @@ namespace YimMenu::Features
 			NoControl
 		};
 
+		enum class ManualInput
+		{
+			None,
+			Drive,
+			ExitVehicle
+		};
+
 		static constexpr float manual_input_deadzone = 0.2f;
 
 		AutoDriveInternal::RoadDriveController m_Route;
 		AutoDriveInternal::SessionToken m_Session;
 		FailureReason m_FailureReason = FailureReason::None;
 
-		static bool HasManualDrivingInput()
+		static float GetControlMagnitude(ControllerInputs input)
 		{
-			const auto steering = std::abs(PAD::GET_CONTROL_NORMAL(0, static_cast<int>(ControllerInputs::INPUT_VEH_MOVE_LR)));
-			const auto accelerate = std::abs(PAD::GET_CONTROL_NORMAL(0, static_cast<int>(ControllerInputs::INPUT_VEH_ACCELERATE)));
-			const auto brake = std::abs(PAD::GET_CONTROL_NORMAL(0, static_cast<int>(ControllerInputs::INPUT_VEH_BRAKE)));
+			const auto action = static_cast<int>(input);
+			return std::max(
+			    std::abs(PAD::GET_CONTROL_NORMAL(0, action)),
+			    std::abs(PAD::GET_DISABLED_CONTROL_NORMAL(0, action)));
+		}
 
-			return steering > manual_input_deadzone
+		static bool IsControlPressed(ControllerInputs input)
+		{
+			const auto action = static_cast<int>(input);
+			return PAD::IS_CONTROL_PRESSED(0, action)
+			    || PAD::IS_DISABLED_CONTROL_PRESSED(0, action);
+		}
+
+		static ManualInput GetManualDrivingInput()
+		{
+			if (IsControlPressed(ControllerInputs::INPUT_VEH_EXIT))
+				return ManualInput::ExitVehicle;
+
+			const auto steering = GetControlMagnitude(ControllerInputs::INPUT_VEH_MOVE_LR);
+			const auto accelerate = GetControlMagnitude(ControllerInputs::INPUT_VEH_ACCELERATE);
+			const auto brake = GetControlMagnitude(ControllerInputs::INPUT_VEH_BRAKE);
+
+			if (steering > manual_input_deadzone
 			    || accelerate > manual_input_deadzone
 			    || brake > manual_input_deadzone
-			    || PAD::IS_CONTROL_PRESSED(0, static_cast<int>(ControllerInputs::INPUT_VEH_HANDBRAKE))
-			    || PAD::IS_CONTROL_PRESSED(0, static_cast<int>(ControllerInputs::INPUT_VEH_EXIT));
+			    || IsControlPressed(ControllerInputs::INPUT_VEH_HANDBRAKE))
+				return ManualInput::Drive;
+
+			return ManualInput::None;
 		}
 
 		void SetFailure(FailureReason reason, std::string_view message = {})
@@ -133,15 +161,33 @@ namespace YimMenu::Features
 
 			auto driver = Self::GetPed();
 			auto vehicle = Self::GetVehicle();
-			if (!ValidateDriver(driver, vehicle))
-				return;
+			const auto isCurrentDriver = driver
+			    && vehicle
+			    && VEHICLE::GET_PED_IN_VEHICLE_SEAT(vehicle.GetHandle(), -1, false) == driver.GetHandle();
 
-			if (HasManualDrivingInput())
+			const auto manualInput = m_Route.HasTask() || isCurrentDriver
+			    ? GetManualDrivingInput()
+			    : ManualInput::None;
+			if (manualInput != ManualInput::None)
 			{
 				AutoDriveInternal::Coordinator::Release(m_Session);
 				SetState(false);
+
+				if (manualInput == ManualInput::ExitVehicle
+				    && driver
+				    && vehicle
+				    && ENTITY::DOES_ENTITY_EXIST(driver.GetHandle())
+				    && ENTITY::DOES_ENTITY_EXIST(vehicle.GetHandle())
+				    && PED::IS_PED_IN_VEHICLE(driver.GetHandle(), vehicle.GetHandle(), false))
+				{
+					TASK::TASK_LEAVE_VEHICLE(driver.GetHandle(), vehicle.GetHandle(), 0);
+				}
+
 				return;
 			}
+
+			if (!ValidateDriver(driver, vehicle))
+				return;
 
 			if (m_Route.Tick(driver, vehicle, "Auto Drive started.") == AutoDriveInternal::RouteResult::DestinationReached)
 			{

--- a/src/game/features/vehicle/AutoDrive.cpp
+++ b/src/game/features/vehicle/AutoDrive.cpp
@@ -1,4 +1,5 @@
 #include "AutoDriveShared.hpp"
+#include "AutoDriveHudTelemetry.hpp"
 
 #include "core/commands/BoolCommand.hpp"
 #include "core/commands/Commands.hpp"
@@ -86,6 +87,7 @@ namespace YimMenu::Features
 
 		void ClearOwnedSession()
 		{
+			AutoDriveInternal::AutoDriveHudTelemetry::Clear(m_Session);
 			m_Route.ClearTask();
 			m_FailureReason = FailureReason::None;
 		}
@@ -187,9 +189,14 @@ namespace YimMenu::Features
 			}
 
 			if (!ValidateDriver(driver, vehicle))
+			{
+				AutoDriveInternal::AutoDriveHudTelemetry::Clear(m_Session);
 				return;
+			}
 
-			if (m_Route.Tick(driver, vehicle, "Auto Drive started.") == AutoDriveInternal::RouteResult::DestinationReached)
+			const auto routeResult = m_Route.Tick(driver, vehicle, "Auto Drive started.");
+			AutoDriveInternal::AutoDriveHudTelemetry::Update(m_Session, driver, vehicle, m_Route.GetStatus());
+			if (routeResult == AutoDriveInternal::RouteResult::DestinationReached)
 			{
 				AutoDriveInternal::Coordinator::Release(m_Session);
 				SetState(false);

--- a/src/game/features/vehicle/AutoDriveHudTelemetry.cpp
+++ b/src/game/features/vehicle/AutoDriveHudTelemetry.cpp
@@ -1,0 +1,824 @@
+#include "AutoDriveHudTelemetry.hpp"
+
+#include "core/commands/BoolCommand.hpp"
+#include "core/util/Joaat.hpp"
+#include "game/gta/Natives.hpp"
+#include "game/gta/Pools.hpp"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <unordered_map>
+
+namespace YimMenu::Features::AutoDriveInternal
+{
+	using namespace std::chrono_literals;
+
+	static BoolCommand _AutoDriveHud{
+	    "autodrivehud",
+	    "Auto Drive HUD",
+	    "Shows a Tesla-style road and traffic visualization while Auto Drive is active",
+	    true};
+
+	namespace
+	{
+		constexpr float kForwardRange = 90.0f;
+		constexpr float kRearRange = 30.0f;
+		constexpr float kLateralRange = 45.0f;
+		constexpr float kVerticalRange = 12.0f;
+		constexpr float kLaneWidth = 3.5f;
+		constexpr float kPi = 3.14159265358979323846f;
+
+		constexpr std::array kTrafficLights = {
+		    "prop_traffic_01a"_J, "prop_traffic_01b"_J, "prop_traffic_01d"_J,
+		    "prop_traffic_02a"_J, "prop_traffic_02b"_J, "prop_traffic_03a"_J,
+		    "prop_traffic_03b"_J, "prop_traffic_lightset_01"_J};
+		constexpr std::array kCones = {
+		    "prop_roadcone01a"_J, "prop_roadcone01b"_J, "prop_roadcone01c"_J,
+		    "prop_roadcone02a"_J, "prop_roadcone02b"_J, "prop_roadcone02c"_J,
+		    "prop_mp_cone_01"_J, "prop_mp_cone_02"_J};
+		constexpr std::array kBarriers = {
+		    "prop_barrier_work01a"_J, "prop_barrier_work01b"_J, "prop_barrier_work01c"_J,
+		    "prop_barrier_work02a"_J, "prop_barrier_work04a"_J, "prop_barrier_work05"_J,
+		    "prop_mp_barrier_01"_J, "prop_mp_barrier_02"_J, "prop_road_memorial_01"_J};
+		constexpr std::array kBarrels = {
+		    "prop_barrel_01a"_J, "prop_barrel_02a"_J, "prop_barrel_02b"_J,
+		    "prop_barrel_03a"_J, "prop_barrel_exp_01a"_J, "prop_traffic_barrel_01"_J};
+		constexpr std::array kBollards = {
+		    "prop_bollard_01a"_J, "prop_bollard_01b"_J, "prop_bollard_01c"_J,
+		    "prop_bollard_03a"_J, "prop_bollard_04"_J, "prop_bollard_05"_J};
+		constexpr std::array kTrees = {
+		    "prop_tree_birch_01"_J, "prop_tree_birch_02"_J, "prop_tree_cedar_02"_J,
+		    "prop_tree_cedar_03"_J, "prop_tree_cedar_04"_J, "prop_tree_cedar_s_01"_J,
+		    "prop_tree_cypress_01"_J, "prop_tree_eng_oak_01"_J, "prop_tree_eucalip_01"_J,
+		    "prop_tree_fallen_01"_J, "prop_tree_jacada_01"_J, "prop_tree_jacada_02"_J,
+		    "prop_tree_lficus_02"_J, "prop_tree_lficus_03"_J, "prop_tree_lficus_05"_J,
+		    "prop_tree_maple_02"_J, "prop_tree_mquite_01"_J, "prop_tree_oak_01"_J,
+		    "prop_tree_olive_01"_J, "prop_tree_pine_01"_J, "prop_tree_pine_02"_J,
+		    "prop_tree_stump_01"_J, "prop_tree_sycamore_01"_J, "prop_tree_willow_01"_J};
+
+		template<std::size_t N>
+		bool Contains(const std::array<Hash, N>& values, Hash model)
+		{
+			return std::find(values.begin(), values.end(), model) != values.end();
+		}
+
+		float Length2D(float x, float y)
+		{
+			return std::sqrt(x * x + y * y);
+		}
+
+		float NormalizeRadians(float value)
+		{
+			while (value > kPi)
+				value -= 2.0f * kPi;
+			while (value < -kPi)
+				value += 2.0f * kPi;
+			return value;
+		}
+
+		bool IsFinite(const Vector3& value)
+		{
+			return std::isfinite(value.x) && std::isfinite(value.y) && std::isfinite(value.z);
+		}
+
+		bool SameToken(SessionToken first, SessionToken second)
+		{
+			return first.m_Owner == second.m_Owner && first.m_Generation == second.m_Generation;
+		}
+
+		struct Basis
+		{
+			Vector3 m_Position{};
+			Vector3 m_Forward{};
+			Vector3 m_Right{};
+			float m_HeadingRadians = 0.0f;
+		};
+
+		HudPoint ToLocal(const Basis& basis, const Vector3& position)
+		{
+			const auto dx = position.x - basis.m_Position.x;
+			const auto dy = position.y - basis.m_Position.y;
+			return {
+			    dx * basis.m_Right.x + dy * basis.m_Right.y,
+			    dx * basis.m_Forward.x + dy * basis.m_Forward.y};
+		}
+
+		HudPoint VectorToLocal(const Basis& basis, const Vector3& vector)
+		{
+			return {
+			    vector.x * basis.m_Right.x + vector.y * basis.m_Right.y,
+			    vector.x * basis.m_Forward.x + vector.y * basis.m_Forward.y};
+		}
+
+		Vector3 OffsetWorld(const Vector3& origin, const Vector3& forward, const Vector3& right, float along, float across)
+		{
+			return {
+			    origin.x + forward.x * along + right.x * across,
+			    origin.y + forward.y * along + right.y * across,
+			    origin.z};
+		}
+
+		bool WithinBroadRange(const Vector3& ego, const rage::fvector3& position)
+		{
+			const auto dx = position.x - ego.x;
+			const auto dy = position.y - ego.y;
+			return dx * dx + dy * dy <= 120.0f * 120.0f && std::abs(position.z - ego.z) <= kVerticalRange;
+		}
+
+		HudEntityKind ClassifyObject(Hash model)
+		{
+			if (Contains(kTrafficLights, model)) return HudEntityKind::TrafficLight;
+			if (Contains(kCones, model)) return HudEntityKind::Cone;
+			if (Contains(kBarriers, model)) return HudEntityKind::Barrier;
+			if (Contains(kBarrels, model)) return HudEntityKind::Barrel;
+			if (Contains(kBollards, model)) return HudEntityKind::Bollard;
+			if (Contains(kTrees, model)) return HudEntityKind::Tree;
+			return HudEntityKind::Obstacle;
+		}
+
+		struct WorldEntity
+		{
+			std::uint32_t m_TrackId = 0;
+			HudEntityKind m_Kind = HudEntityKind::Obstacle;
+			Vector3 m_Position{};
+			Vector3 m_Velocity{};
+			HudPoint m_Footprint{1.0f, 1.0f};
+			float m_HeadingRadians = 0.0f;
+		};
+
+		struct RoadCache
+		{
+			bool m_Valid = false;
+			bool m_Stable = false;
+			Vector3 m_Center{};
+			Vector3 m_Tangent{};
+			Vector3 m_Right{};
+			std::vector<float> m_LaneCenters;
+			std::vector<std::vector<Vector3>> m_Boundaries;
+		};
+
+		struct RouteCache
+		{
+			bool m_Reliable = false;
+			bool m_Calculating = false;
+			bool m_Predicted = false;
+			std::vector<Vector3> m_Points;
+		};
+
+		struct LaneChangeState
+		{
+			HudManeuver m_Active = HudManeuver::None;
+			std::chrono::steady_clock::time_point m_LastSample{};
+			std::chrono::steady_clock::time_point m_CandidateSince{};
+			std::chrono::steady_clock::time_point m_ActiveSince{};
+			std::chrono::steady_clock::time_point m_StableSince{};
+			float m_LastOffset = 0.0f;
+			float m_CandidateStart = 0.0f;
+			float m_FilteredVelocity = 0.0f;
+			int m_CandidateDirection = 0;
+		};
+
+		class TelemetryService
+		{
+			std::atomic<std::shared_ptr<const AutoDriveHudSnapshot>> m_Published;
+			SessionToken m_ActiveToken{};
+			std::vector<WorldEntity> m_Vehicles;
+			std::vector<WorldEntity> m_Peds;
+			std::vector<WorldEntity> m_Objects;
+			RoadCache m_Road;
+			RouteCache m_Route;
+			LaneChangeState m_LaneChange;
+			std::unordered_map<Hash, HudPoint> m_DimensionCache;
+			std::chrono::steady_clock::time_point m_LastPublish{};
+			std::chrono::steady_clock::time_point m_LastVehiclePedScan{};
+			std::chrono::steady_clock::time_point m_LastObjectScan{};
+			std::chrono::steady_clock::time_point m_LastRoadScan{};
+			std::chrono::steady_clock::time_point m_LastRouteScan{};
+			std::chrono::steady_clock::time_point m_LastVehicleSuccess{};
+			std::chrono::steady_clock::time_point m_LastPedSuccess{};
+			std::chrono::steady_clock::time_point m_LastObjectSuccess{};
+			bool m_VehicleScanHealthy = false;
+			bool m_PedScanHealthy = false;
+			bool m_ObjectScanHealthy = false;
+
+			HudPoint GetFootprint(Hash model, HudEntityKind kind)
+			{
+				if (const auto found = m_DimensionCache.find(model); found != m_DimensionCache.end())
+					return found->second;
+
+				Vector3 minimum{};
+				Vector3 maximum{};
+				MISC::GET_MODEL_DIMENSIONS(model, &minimum, &maximum);
+				auto width = std::abs(maximum.x - minimum.x);
+				auto length = std::abs(maximum.y - minimum.y);
+				if (!std::isfinite(width) || width < 0.1f)
+					width = kind == HudEntityKind::Pedestrian ? 0.7f : 1.0f;
+				if (!std::isfinite(length) || length < 0.1f)
+					length = kind == HudEntityKind::Pedestrian ? 0.7f : 1.0f;
+
+				HudPoint result{std::clamp(width, 0.35f, 8.0f), std::clamp(length, 0.35f, 16.0f)};
+				m_DimensionCache.emplace(model, result);
+				return result;
+			}
+
+			static Basis GetBasis(Vehicle vehicle)
+			{
+				const auto position = vehicle.GetPosition();
+				auto forward = ENTITY::GET_ENTITY_FORWARD_VECTOR(vehicle.GetHandle());
+				const auto magnitude = Length2D(forward.x, forward.y);
+				if (magnitude > 0.001f)
+				{
+					forward.x /= magnitude;
+					forward.y /= magnitude;
+				}
+				else
+				{
+					forward = {0.0f, 1.0f, 0.0f};
+				}
+
+				return {
+				    {position.x, position.y, position.z},
+				    forward,
+				    {forward.y, -forward.x, 0.0f},
+				    std::atan2(-forward.x, forward.y)};
+			}
+
+			void ResetForToken(SessionToken token)
+			{
+				m_ActiveToken = token;
+				m_Vehicles.clear();
+				m_Peds.clear();
+				m_Objects.clear();
+				m_Road = {};
+				m_Route = {};
+				m_LaneChange = {};
+				m_LastPublish = {};
+				m_LastVehiclePedScan = {};
+				m_LastObjectScan = {};
+				m_LastRoadScan = {};
+				m_LastRouteScan = {};
+				m_LastVehicleSuccess = {};
+				m_LastPedSuccess = {};
+				m_LastObjectSuccess = {};
+				m_VehicleScanHealthy = false;
+				m_PedScanHealthy = false;
+				m_ObjectScanHealthy = false;
+			}
+
+			void ScanVehiclesAndPeds(const Basis& basis, Vehicle egoVehicle, std::chrono::steady_clock::time_point now)
+			{
+				std::vector<WorldEntity> vehicles;
+				if (auto pool = GetVehiclePool())
+				{
+					vehicles.reserve(std::min<std::uint32_t>(pool->m_Size, 96));
+					for (auto vehicle : Pools::GetVehicles())
+					{
+						const auto position = vehicle.GetPosition();
+						if (!WithinBroadRange(basis.m_Position, position))
+							continue;
+						const auto handle = vehicle.GetHandle();
+						if (!handle || handle == egoVehicle.GetHandle() || !ENTITY::DOES_ENTITY_EXIST(handle))
+							continue;
+						const auto model = ENTITY::GET_ENTITY_MODEL(handle);
+						const auto velocity = ENTITY::GET_ENTITY_VELOCITY(handle);
+						vehicles.push_back({
+						    static_cast<std::uint32_t>(handle), HudEntityKind::Vehicle,
+						    {position.x, position.y, position.z}, velocity,
+						    GetFootprint(model, HudEntityKind::Vehicle),
+						    ENTITY::GET_ENTITY_HEADING(handle) * kPi / 180.0f});
+					}
+					m_Vehicles = std::move(vehicles);
+					m_LastVehicleSuccess = now;
+					m_VehicleScanHealthy = true;
+				}
+				else
+					m_VehicleScanHealthy = false;
+
+				std::vector<WorldEntity> peds;
+				if (auto pool = GetPedPool())
+				{
+					peds.reserve(std::min<std::uint32_t>(pool->m_Size, 80));
+					for (auto ped : Pools::GetPeds())
+					{
+						const auto position = ped.GetPosition();
+						if (!WithinBroadRange(basis.m_Position, position))
+							continue;
+						const auto handle = ped.GetHandle();
+						if (!handle || !ENTITY::DOES_ENTITY_EXIST(handle) || PED::IS_PED_A_PLAYER(handle)
+						    || ENTITY::IS_ENTITY_DEAD(handle, false) || !PED::IS_PED_HUMAN(handle)
+						    || PED::IS_PED_IN_ANY_VEHICLE(handle, false))
+							continue;
+						const auto model = ENTITY::GET_ENTITY_MODEL(handle);
+						peds.push_back({
+						    static_cast<std::uint32_t>(handle), HudEntityKind::Pedestrian,
+						    {position.x, position.y, position.z}, ENTITY::GET_ENTITY_VELOCITY(handle),
+						    GetFootprint(model, HudEntityKind::Pedestrian),
+						    ENTITY::GET_ENTITY_HEADING(handle) * kPi / 180.0f});
+					}
+					m_Peds = std::move(peds);
+					m_LastPedSuccess = now;
+					m_PedScanHealthy = true;
+				}
+				else
+					m_PedScanHealthy = false;
+			}
+
+			void ScanObjects(const Basis& basis, std::chrono::steady_clock::time_point now)
+			{
+				auto pool = GetObjectPool();
+				if (!pool)
+				{
+					m_ObjectScanHealthy = false;
+					return;
+				}
+
+				std::vector<WorldEntity> objects;
+				objects.reserve(std::min<std::uint32_t>(pool->m_Size, 160));
+				for (auto object : Pools::GetObjects())
+				{
+					const auto position = object.GetPosition();
+					if (!WithinBroadRange(basis.m_Position, position))
+						continue;
+					const auto handle = object.GetHandle();
+					if (!handle || !ENTITY::DOES_ENTITY_EXIST(handle))
+						continue;
+
+					const auto model = ENTITY::GET_ENTITY_MODEL(handle);
+					const auto kind = ClassifyObject(model);
+					const auto velocity = ENTITY::GET_ENTITY_VELOCITY(handle);
+					if (kind == HudEntityKind::Obstacle)
+					{
+						const auto local = ToLocal(basis, {position.x, position.y, position.z});
+						const auto moving = Length2D(velocity.x, velocity.y) > 0.25f;
+						const auto close = Length2D(local.m_X, local.m_Y) < 18.0f;
+						const auto inCorridor = local.m_Y > -5.0f && local.m_Y < 50.0f && std::abs(local.m_X) < 7.0f;
+						if ((!moving && !close && !inCorridor) || ENTITY::GET_ENTITY_COLLISION_DISABLED(handle))
+							continue;
+					}
+
+					objects.push_back({
+					    static_cast<std::uint32_t>(handle), kind,
+					    {position.x, position.y, position.z}, velocity,
+					    GetFootprint(model, kind),
+					    ENTITY::GET_ENTITY_HEADING(handle) * kPi / 180.0f});
+				}
+				m_Objects = std::move(objects);
+				m_LastObjectSuccess = now;
+				m_ObjectScanHealthy = true;
+			}
+
+			void ExpireFailedScans(std::chrono::steady_clock::time_point now)
+			{
+				if (!m_VehicleScanHealthy && m_LastVehicleSuccess != std::chrono::steady_clock::time_point{} && now - m_LastVehicleSuccess > 500ms)
+					m_Vehicles.clear();
+				if (!m_PedScanHealthy && m_LastPedSuccess != std::chrono::steady_clock::time_point{} && now - m_LastPedSuccess > 500ms)
+					m_Peds.clear();
+				if (!m_ObjectScanHealthy && m_LastObjectSuccess != std::chrono::steady_clock::time_point{} && now - m_LastObjectSuccess > 500ms)
+					m_Objects.clear();
+			}
+
+			void RefreshRoad(const Basis& basis)
+			{
+				Vector3 first{};
+				Vector3 second{};
+				int lanesForward = 0;
+				int lanesBackward = 0;
+				float medianWidth = 0.0f;
+				if (!PATH::GET_CLOSEST_ROAD(
+				        basis.m_Position.x, basis.m_Position.y, basis.m_Position.z,
+				        1.0f, 1, &first, &second,
+				        &lanesForward, &lanesBackward, &medianWidth, false)
+				    || !IsFinite(first) || !IsFinite(second))
+				{
+					m_Road = {};
+					return;
+				}
+
+				auto tx = second.x - first.x;
+				auto ty = second.y - first.y;
+				const auto length = Length2D(tx, ty);
+				if (length < 2.0f)
+				{
+					m_Road = {};
+					return;
+				}
+				tx /= length;
+				ty /= length;
+				if (tx * basis.m_Forward.x + ty * basis.m_Forward.y < 0.0f)
+				{
+					tx = -tx;
+					ty = -ty;
+				}
+
+				const auto previousTangent = m_Road.m_Tangent;
+				const auto hadPrevious = m_Road.m_Valid;
+				const auto edgeX = basis.m_Position.x - first.x;
+				const auto edgeY = basis.m_Position.y - first.y;
+				const auto projection = edgeX * tx + edgeY * ty;
+				const Vector3 center{first.x + tx * projection, first.y + ty * projection, basis.m_Position.z};
+				const Vector3 tangent{tx, ty, 0.0f};
+				const Vector3 right{ty, -tx, 0.0f};
+
+				RoadCache road;
+				road.m_Valid = true;
+				road.m_Center = center;
+				road.m_Tangent = tangent;
+				road.m_Right = right;
+				const auto vehicleAlignment = std::abs(tx * basis.m_Forward.x + ty * basis.m_Forward.y);
+				const auto previousAlignment = hadPrevious
+				    ? std::abs(tx * previousTangent.x + ty * previousTangent.y)
+				    : 1.0f;
+				road.m_Stable = vehicleAlignment > 0.57f && previousAlignment > 0.94f;
+
+				lanesForward = std::clamp(lanesForward, 0, 8);
+				lanesBackward = std::clamp(lanesBackward, 0, 8);
+				const auto totalLanes = std::clamp(lanesForward + lanesBackward, 1, 8);
+				medianWidth = std::clamp(medianWidth, 0.0f, 8.0f);
+				std::vector<float> boundaries;
+				if (lanesForward > 0 && lanesBackward > 0)
+				{
+					for (int lane = 0; lane <= lanesForward; ++lane)
+						boundaries.push_back(medianWidth * 0.5f + lane * kLaneWidth);
+					for (int lane = 0; lane <= lanesBackward; ++lane)
+						boundaries.push_back(-medianWidth * 0.5f - lane * kLaneWidth);
+				}
+				else
+				{
+					for (int lane = 0; lane <= totalLanes; ++lane)
+						boundaries.push_back((lane - totalLanes * 0.5f) * kLaneWidth);
+				}
+				std::sort(boundaries.begin(), boundaries.end());
+				boundaries.erase(std::unique(boundaries.begin(), boundaries.end()), boundaries.end());
+
+				for (std::size_t lane = 1; lane < boundaries.size(); ++lane)
+				{
+					const auto gap = boundaries[lane] - boundaries[lane - 1];
+					if (gap <= kLaneWidth * 1.6f)
+						road.m_LaneCenters.push_back((boundaries[lane] + boundaries[lane - 1]) * 0.5f);
+				}
+
+				for (const auto offset : boundaries)
+				{
+					auto& line = road.m_Boundaries.emplace_back();
+					line.reserve(10);
+					for (float distance = -25.0f; distance <= 110.0f; distance += 15.0f)
+						line.push_back(OffsetWorld(center, tangent, right, distance, offset));
+				}
+
+				m_Road = std::move(road);
+			}
+
+			void RefreshRoute(const Basis& basis, const RoadDriveStatus& status)
+			{
+				RouteCache route;
+				if (status.m_Phase == RoutePhase::Wander)
+				{
+					route.m_Predicted = true;
+					route.m_Reliable = m_Road.m_Valid && m_Road.m_Stable;
+					if (route.m_Reliable)
+					{
+						for (float distance = 0.0f; distance <= 70.0f; distance += 7.0f)
+							route.m_Points.push_back(OffsetWorld(m_Road.m_Center, m_Road.m_Tangent, m_Road.m_Right, distance, 0.0f));
+					}
+					m_Route = std::move(route);
+					return;
+				}
+
+				if (status.m_Phase != RoutePhase::Navigation
+				    && status.m_Phase != RoutePhase::TargetLost
+				    && status.m_Phase != RoutePhase::Arrived)
+				{
+					m_Route = {};
+					return;
+				}
+
+				route.m_Calculating = status.m_Phase == RoutePhase::TargetLost || !PATH::GET_GPS_BLIP_ROUTE_FOUND();
+				const auto slot = status.m_TargetSource == NavigationTargetSource::UserWaypoint ? 0 : 1;
+				if (!route.m_Calculating)
+				{
+					Vector3 previous{};
+					bool hasPrevious = false;
+					for (float distance = 0.0f; distance <= 160.0f; distance += 8.0f)
+					{
+						Vector3 point{};
+						if (!PATH::GET_POS_ALONG_GPS_TYPE_ROUTE(&point, true, distance, slot) || !IsFinite(point))
+							break;
+						if (hasPrevious && Length2D(point.x - previous.x, point.y - previous.y) > 30.0f)
+							break;
+						route.m_Points.push_back(point);
+						previous = point;
+						hasPrevious = true;
+					}
+				}
+
+				route.m_Reliable = route.m_Points.size() >= 2;
+				if (!route.m_Reliable)
+				{
+					route.m_Points.clear();
+					route.m_Calculating = true;
+				}
+				m_Route = std::move(route);
+			}
+
+			bool RouteIsTurning(const Basis& basis) const
+			{
+				if (!m_Route.m_Reliable || m_Route.m_Predicted || m_Route.m_Points.size() < 3)
+					return false;
+				const auto first = ToLocal(basis, m_Route.m_Points.front());
+				for (std::size_t index = 2; index < m_Route.m_Points.size(); ++index)
+				{
+					const auto current = ToLocal(basis, m_Route.m_Points[index]);
+					if (current.m_Y > 40.0f)
+						break;
+					const auto dx = current.m_X - first.m_X;
+					const auto dy = current.m_Y - first.m_Y;
+					const auto length = Length2D(dx, dy);
+					if (length > 8.0f && std::abs(dx / length) > 0.34f)
+						return true;
+				}
+				return false;
+			}
+
+			float CurrentLateralOffset(const Basis& basis) const
+			{
+				const auto dx = basis.m_Position.x - m_Road.m_Center.x;
+				const auto dy = basis.m_Position.y - m_Road.m_Center.y;
+				return dx * m_Road.m_Right.x + dy * m_Road.m_Right.y;
+			}
+
+			float NearestLaneCenterDistance(float offset) const
+			{
+				float nearest = std::numeric_limits<float>::max();
+				for (const auto center : m_Road.m_LaneCenters)
+					nearest = std::min(nearest, std::abs(offset - center));
+				return nearest;
+			}
+
+			HudManeuver UpdateLaneChange(const Basis& basis, float speed, std::chrono::steady_clock::time_point now)
+			{
+				const auto eligible = speed >= 5.0f && m_Road.m_Valid && m_Road.m_Stable && !RouteIsTurning(basis);
+				if (!eligible)
+				{
+					m_LaneChange = {};
+					return HudManeuver::None;
+				}
+
+				const auto offset = CurrentLateralOffset(basis);
+				if (m_LaneChange.m_LastSample == std::chrono::steady_clock::time_point{})
+				{
+					m_LaneChange.m_LastSample = now;
+					m_LaneChange.m_LastOffset = offset;
+					return HudManeuver::None;
+				}
+
+				const auto elapsed = std::chrono::duration<float>(now - m_LaneChange.m_LastSample).count();
+				if (elapsed <= 0.001f || elapsed > 0.5f)
+				{
+					m_LaneChange.m_LastSample = now;
+					m_LaneChange.m_LastOffset = offset;
+					m_LaneChange.m_FilteredVelocity = 0.0f;
+					return m_LaneChange.m_Active;
+				}
+
+				const auto rawVelocity = (offset - m_LaneChange.m_LastOffset) / elapsed;
+				m_LaneChange.m_FilteredVelocity = m_LaneChange.m_FilteredVelocity * 0.7f + rawVelocity * 0.3f;
+				m_LaneChange.m_LastOffset = offset;
+				m_LaneChange.m_LastSample = now;
+
+				if (m_LaneChange.m_Active == HudManeuver::None)
+				{
+					const auto direction = m_LaneChange.m_FilteredVelocity > 0.5f ? 1
+					    : m_LaneChange.m_FilteredVelocity < -0.5f            ? -1
+					                                                        : 0;
+					if (!direction)
+					{
+						m_LaneChange.m_CandidateDirection = 0;
+						m_LaneChange.m_CandidateSince = {};
+						return HudManeuver::None;
+					}
+
+					if (direction != m_LaneChange.m_CandidateDirection)
+					{
+						m_LaneChange.m_CandidateDirection = direction;
+						m_LaneChange.m_CandidateStart = offset;
+						m_LaneChange.m_CandidateSince = now;
+						return HudManeuver::None;
+					}
+
+					if (now - m_LaneChange.m_CandidateSince >= 250ms
+					    && std::abs(offset - m_LaneChange.m_CandidateStart) > 0.35f)
+					{
+						m_LaneChange.m_Active = direction > 0 ? HudManeuver::LaneChangeRight : HudManeuver::LaneChangeLeft;
+						m_LaneChange.m_ActiveSince = now;
+						m_LaneChange.m_StableSince = {};
+					}
+					return m_LaneChange.m_Active;
+				}
+
+				if (now - m_LaneChange.m_ActiveSince >= 4s)
+				{
+					m_LaneChange = {};
+					return HudManeuver::None;
+				}
+
+				const auto settled = std::abs(m_LaneChange.m_FilteredVelocity) < 0.2f
+				    && NearestLaneCenterDistance(offset) < 0.45f;
+				if (settled)
+				{
+					if (m_LaneChange.m_StableSince == std::chrono::steady_clock::time_point{})
+						m_LaneChange.m_StableSince = now;
+					else if (now - m_LaneChange.m_StableSince >= 500ms)
+					{
+						m_LaneChange = {};
+						return HudManeuver::None;
+					}
+				}
+				else
+				{
+					m_LaneChange.m_StableSince = {};
+				}
+				return m_LaneChange.m_Active;
+			}
+
+			static bool InHudRange(const HudPoint& point)
+			{
+				return point.m_Y >= -kRearRange && point.m_Y <= kForwardRange && std::abs(point.m_X) <= kLateralRange;
+			}
+
+			void AppendEntities(
+			    std::vector<HudEntitySnapshot>& output,
+			    const std::vector<WorldEntity>& source,
+			    const Basis& basis,
+			    std::size_t maximum) const
+			{
+				std::vector<std::pair<float, HudEntitySnapshot>> sorted;
+				sorted.reserve(source.size());
+				for (const auto& entity : source)
+				{
+					const auto local = ToLocal(basis, entity.m_Position);
+					if (!InHudRange(local) || std::abs(entity.m_Position.z - basis.m_Position.z) > kVerticalRange)
+						continue;
+					HudEntitySnapshot snapshot;
+					snapshot.m_TrackId = entity.m_TrackId;
+					snapshot.m_Kind = entity.m_Kind;
+					snapshot.m_Position = local;
+					snapshot.m_Velocity = VectorToLocal(basis, entity.m_Velocity);
+					snapshot.m_Footprint = entity.m_Footprint;
+					snapshot.m_RelativeHeadingRadians = NormalizeRadians(entity.m_HeadingRadians - basis.m_HeadingRadians);
+					sorted.emplace_back(local.m_X * local.m_X + local.m_Y * local.m_Y, snapshot);
+				}
+				std::sort(sorted.begin(), sorted.end(), [](const auto& left, const auto& right) {
+					return left.first < right.first;
+				});
+				for (std::size_t index = 0; index < std::min(maximum, sorted.size()); ++index)
+					output.push_back(std::move(sorted[index].second));
+			}
+
+			void InferRedTrafficLight(std::vector<HudEntitySnapshot>& entities, bool stoppedAtLight) const
+			{
+				if (!stoppedAtLight)
+					return;
+				HudEntitySnapshot* nearest = nullptr;
+				float nearestDistance = std::numeric_limits<float>::max();
+				for (auto& entity : entities)
+				{
+					if (entity.m_Kind != HudEntityKind::TrafficLight || entity.m_Position.m_Y < 0.0f
+					    || entity.m_Position.m_Y > 35.0f || std::abs(entity.m_Position.m_X) > 6.0f)
+						continue;
+					const auto distance = Length2D(entity.m_Position.m_X, entity.m_Position.m_Y);
+					if (distance < nearestDistance)
+					{
+						nearest = &entity;
+						nearestDistance = distance;
+					}
+				}
+				if (nearest)
+					nearest->m_TrafficLightState = TrafficLightState::RedInferred;
+			}
+
+		public:
+			TelemetryService()
+			{
+				m_Published.store(std::make_shared<const AutoDriveHudSnapshot>());
+			}
+
+			void Update(SessionToken token, Ped driver, Vehicle vehicle, const RoadDriveStatus& status)
+			{
+				if (!Coordinator::Owns(token) || !driver || !vehicle)
+					return;
+				if (!SameToken(m_ActiveToken, token))
+					ResetForToken(token);
+
+				const auto now = std::chrono::steady_clock::now();
+				if (m_LastPublish != std::chrono::steady_clock::time_point{} && now - m_LastPublish < 50ms)
+					return;
+				const auto basis = GetBasis(vehicle);
+
+				if (m_LastVehiclePedScan == std::chrono::steady_clock::time_point{} || now - m_LastVehiclePedScan >= 100ms)
+				{
+					ScanVehiclesAndPeds(basis, vehicle, now);
+					m_LastVehiclePedScan = now;
+				}
+				if (m_LastObjectScan == std::chrono::steady_clock::time_point{} || now - m_LastObjectScan >= 333ms)
+				{
+					ScanObjects(basis, now);
+					m_LastObjectScan = now;
+				}
+				if (m_LastRoadScan == std::chrono::steady_clock::time_point{} || now - m_LastRoadScan >= 200ms)
+				{
+					RefreshRoad(basis);
+					m_LastRoadScan = now;
+				}
+				if (m_LastRouteScan == std::chrono::steady_clock::time_point{} || now - m_LastRouteScan >= 250ms)
+				{
+					RefreshRoute(basis, status);
+					m_LastRouteScan = now;
+				}
+				ExpireFailedScans(now);
+
+				auto snapshot = std::make_shared<AutoDriveHudSnapshot>();
+				snapshot->m_Visible = status.m_HasTask && _AutoDriveHud.GetState();
+				snapshot->m_Suppressed = CAMERA::IS_SCREEN_FADED_OUT() || CAMERA::IS_SCREEN_FADING_OUT() || CAMERA::IS_SCREEN_FADING_IN()
+				    || HUD::IS_PAUSE_MENU_ACTIVE() || HUD::IS_WARNING_MESSAGE_ACTIVE()
+				    || CUTSCENE::IS_CUTSCENE_ACTIVE() || CUTSCENE::IS_CUTSCENE_PLAYING();
+				snapshot->m_Owner = token.m_Owner;
+				snapshot->m_Phase = status.m_Phase;
+				snapshot->m_SpeedKph = std::max(0, static_cast<int>(std::lround(vehicle.GetSpeed() * 3.6f)));
+				snapshot->m_TargetSpeedKph = GetCruiseSpeedKph();
+				snapshot->m_Maneuver = UpdateLaneChange(basis, vehicle.GetSpeed(), now);
+				snapshot->m_RouteReliable = m_Route.m_Reliable;
+				snapshot->m_RouteCalculating = m_Route.m_Calculating;
+				snapshot->m_RoutePredicted = m_Route.m_Predicted;
+				for (const auto& point : m_Route.m_Points)
+				{
+					const auto local = ToLocal(basis, point);
+					if (local.m_Y >= -10.0f && local.m_Y <= 170.0f && std::abs(local.m_X) <= 70.0f)
+						snapshot->m_RoutePoints.push_back(local);
+				}
+				if (m_Road.m_Valid && m_Road.m_Stable)
+				{
+					for (const auto& worldLine : m_Road.m_Boundaries)
+					{
+						auto& line = snapshot->m_LaneBoundaries.emplace_back();
+						line.reserve(worldLine.size());
+						for (const auto& point : worldLine)
+							line.push_back(ToLocal(basis, point));
+					}
+				}
+
+				snapshot->m_Entities.reserve(240);
+				AppendEntities(snapshot->m_Entities, m_Vehicles, basis, 64);
+				AppendEntities(snapshot->m_Entities, m_Peds, basis, 48);
+				AppendEntities(snapshot->m_Entities, m_Objects, basis, 128);
+				InferRedTrafficLight(snapshot->m_Entities, VEHICLE::IS_VEHICLE_STOPPED_AT_TRAFFIC_LIGHTS(vehicle.GetHandle()));
+				snapshot->m_CapturedAt = now;
+
+				m_LastPublish = now;
+				m_Published.store(std::move(snapshot), std::memory_order_release);
+			}
+
+			void Clear(SessionToken token)
+			{
+				if (!SameToken(m_ActiveToken, token))
+					return;
+				ResetForToken({});
+				m_Published.store(std::make_shared<const AutoDriveHudSnapshot>(), std::memory_order_release);
+			}
+
+			std::shared_ptr<const AutoDriveHudSnapshot> GetSnapshot() const
+			{
+				return m_Published.load(std::memory_order_acquire);
+			}
+		};
+
+		TelemetryService& GetTelemetryService()
+		{
+			static TelemetryService service;
+			return service;
+		}
+	}
+
+	void AutoDriveHudTelemetry::Update(SessionToken token, Ped driver, Vehicle vehicle, const RoadDriveStatus& status)
+	{
+		GetTelemetryService().Update(token, driver, vehicle, status);
+	}
+
+	void AutoDriveHudTelemetry::Clear(SessionToken token)
+	{
+		GetTelemetryService().Clear(token);
+	}
+
+	std::shared_ptr<const AutoDriveHudSnapshot> AutoDriveHudTelemetry::GetSnapshot()
+	{
+		return GetTelemetryService().GetSnapshot();
+	}
+
+	bool AutoDriveHudTelemetry::IsEnabled()
+	{
+		return _AutoDriveHud.GetState();
+	}
+}

--- a/src/game/features/vehicle/AutoDriveHudTelemetry.cpp
+++ b/src/game/features/vehicle/AutoDriveHudTelemetry.cpp
@@ -7,7 +7,7 @@
 
 #include <algorithm>
 #include <array>
-#include <atomic>
+#include <mutex>
 #include <cmath>
 #include <limits>
 #include <memory>
@@ -184,7 +184,8 @@ namespace YimMenu::Features::AutoDriveInternal
 
 		class TelemetryService
 		{
-			std::atomic<std::shared_ptr<const AutoDriveHudSnapshot>> m_Published;
+			std::shared_ptr<const AutoDriveHudSnapshot> m_Published;
+		mutable std::mutex m_PublishedMtx;
 			SessionToken m_ActiveToken{};
 			std::vector<WorldEntity> m_Vehicles;
 			std::vector<WorldEntity> m_Peds;
@@ -703,7 +704,7 @@ namespace YimMenu::Features::AutoDriveInternal
 		public:
 			TelemetryService()
 			{
-				m_Published.store(std::make_shared<const AutoDriveHudSnapshot>());
+				{ std::lock_guard l(m_PublishedMtx); m_Published = std::make_shared<const AutoDriveHudSnapshot>(); }
 			}
 
 			void Update(SessionToken token, Ped driver, Vehicle vehicle, const RoadDriveStatus& status)
@@ -778,7 +779,7 @@ namespace YimMenu::Features::AutoDriveInternal
 				snapshot->m_CapturedAt = now;
 
 				m_LastPublish = now;
-				m_Published.store(std::move(snapshot), std::memory_order_release);
+				{ std::lock_guard l(m_PublishedMtx); m_Published = std::move(snapshot); }
 			}
 
 			void Clear(SessionToken token)
@@ -786,12 +787,12 @@ namespace YimMenu::Features::AutoDriveInternal
 				if (!SameToken(m_ActiveToken, token))
 					return;
 				ResetForToken({});
-				m_Published.store(std::make_shared<const AutoDriveHudSnapshot>(), std::memory_order_release);
+				{ std::lock_guard l(m_PublishedMtx); m_Published = std::make_shared<const AutoDriveHudSnapshot>(); }
 			}
 
 			std::shared_ptr<const AutoDriveHudSnapshot> GetSnapshot() const
 			{
-				return m_Published.load(std::memory_order_acquire);
+				{ std::lock_guard l(m_PublishedMtx); return m_Published; }
 			}
 		};
 

--- a/src/game/features/vehicle/AutoDriveHudTelemetry.hpp
+++ b/src/game/features/vehicle/AutoDriveHudTelemetry.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "AutoDriveShared.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace YimMenu::Features::AutoDriveInternal
+{
+	struct HudPoint
+	{
+		float m_X = 0.0f; // metres to the right of the ego vehicle
+		float m_Y = 0.0f; // metres in front of the ego vehicle
+	};
+
+	enum class HudEntityKind
+	{
+		Vehicle,
+		Pedestrian,
+		TrafficLight,
+		Cone,
+		Barrier,
+		Barrel,
+		Bollard,
+		Tree,
+		Obstacle
+	};
+
+	enum class TrafficLightState
+	{
+		Unknown,
+		RedInferred
+	};
+
+	enum class HudManeuver
+	{
+		None,
+		LaneChangeLeft,
+		LaneChangeRight
+	};
+
+	struct HudEntitySnapshot
+	{
+		std::uint32_t m_TrackId = 0;
+		HudEntityKind m_Kind = HudEntityKind::Obstacle;
+		TrafficLightState m_TrafficLightState = TrafficLightState::Unknown;
+		HudPoint m_Position{};
+		HudPoint m_Velocity{};
+		HudPoint m_Footprint{1.0f, 1.0f};
+		float m_RelativeHeadingRadians = 0.0f;
+	};
+
+	struct AutoDriveHudSnapshot
+	{
+		bool m_Visible = false;
+		bool m_Suppressed = false;
+		Owner m_Owner = Owner::None;
+		RoutePhase m_Phase = RoutePhase::Idle;
+		int m_SpeedKph = 0;
+		int m_TargetSpeedKph = 0;
+		HudManeuver m_Maneuver = HudManeuver::None;
+		bool m_RouteReliable = false;
+		bool m_RouteCalculating = false;
+		bool m_RoutePredicted = false;
+		std::vector<HudPoint> m_RoutePoints;
+		std::vector<std::vector<HudPoint>> m_LaneBoundaries;
+		std::vector<HudEntitySnapshot> m_Entities;
+		std::chrono::steady_clock::time_point m_CapturedAt{};
+	};
+
+	class AutoDriveHudTelemetry
+	{
+	public:
+		static void Update(SessionToken token, Ped driver, Vehicle vehicle, const RoadDriveStatus& status);
+		static void Clear(SessionToken token);
+		static std::shared_ptr<const AutoDriveHudSnapshot> GetSnapshot();
+		static bool IsEnabled();
+	};
+}

--- a/src/game/features/vehicle/AutoDriveShared.cpp
+++ b/src/game/features/vehicle/AutoDriveShared.cpp
@@ -1,0 +1,715 @@
+#include "AutoDriveShared.hpp"
+
+#include "core/commands/IntCommand.hpp"
+#include "core/commands/ListCommand.hpp"
+#include "game/gta/Natives.hpp"
+#include "types/blip/BlipSprite.hpp"
+#include "types/script/HudColor.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <format>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace YimMenu::Features::AutoDriveInternal
+{
+	static constexpr int lawful_driving_style = 786603;
+	static constexpr int ignore_lights_driving_style = 2883621;
+	// Keep this value stable so existing serialized settings continue to select Aggressive.
+	static constexpr int aggressive_driving_style = 1074528293;
+	static constexpr int aggressive_driving_flags = 1074529087;
+	static constexpr int reckless_driving_style = 1074529086;
+	static constexpr float target_move_threshold_squared = 25.0f;
+	static constexpr std::array yellow_mission_blip_colours = {5, 16, 20, 28, 33, 60, 66};
+
+	static IntCommand _AutoDriveSpeed{
+	    "autodrivespeed",
+	    "Cruise Speed (km/h)",
+	    "The target speed used by Auto Drive",
+	    20,
+	    160,
+	    70};
+
+	static std::vector<std::pair<int, const char*>> g_AutoDriveStyles = {
+	    {lawful_driving_style, "Lawful"},
+	    {ignore_lights_driving_style, "Ignore Traffic Lights"},
+	    {aggressive_driving_style, "Aggressive"},
+	    {reckless_driving_style, "Reckless (No Vehicle Braking)"}};
+
+	static ListCommand _AutoDriveStyle{
+	    "autodrivestyle",
+	    "Driving Style",
+	    "How Auto Drive behaves around traffic and traffic lights",
+	    g_AutoDriveStyles,
+	    lawful_driving_style};
+
+	static float DistanceSquared2D(const Vector3& first, const Vector3& second)
+	{
+		const auto deltaX = first.x - second.x;
+		const auto deltaY = first.y - second.y;
+		return deltaX * deltaX + deltaY * deltaY;
+	}
+
+	static float DistanceSquared2D(const rage::fvector3& first, const Vector3& second)
+	{
+		const auto deltaX = first.x - second.x;
+		const auto deltaY = first.y - second.y;
+		return deltaX * deltaX + deltaY * deltaY;
+	}
+
+	static float GetCruiseSpeed()
+	{
+		return GetCruiseSpeedKph() / 3.6f;
+	}
+
+	static constexpr int ResolveDrivingStyle(int drivingStyle)
+	{
+		return drivingStyle == aggressive_driving_style ? aggressive_driving_flags : drivingStyle;
+	}
+
+	static const char* GetDrivingStyleName(int drivingStyle)
+	{
+		for (const auto& [value, name] : g_AutoDriveStyles)
+		{
+			if (value == drivingStyle)
+				return name;
+		}
+
+		return "Unknown";
+	}
+
+	static bool IsValidLocationName(const char* name)
+	{
+		return name && name[0] != '\0' && std::string_view(name) != "NULL";
+	}
+
+	static std::string GetDestinationName(const Vector3& destination)
+	{
+		Hash streetHash = 0;
+		Hash crossingRoadHash = 0;
+		PATH::GET_STREET_NAME_AT_COORD(
+		    destination.x,
+		    destination.y,
+		    destination.z,
+		    &streetHash,
+		    &crossingRoadHash);
+
+		const auto streetName = HUD::GET_STREET_NAME_FROM_HASH_KEY(streetHash);
+		const auto crossingRoadName = HUD::GET_STREET_NAME_FROM_HASH_KEY(crossingRoadHash);
+		if (IsValidLocationName(streetName))
+		{
+			if (IsValidLocationName(crossingRoadName) && std::string_view(streetName) != crossingRoadName)
+				return std::format("{} / {}", streetName, crossingRoadName);
+
+			return streetName;
+		}
+
+		const auto zoneLabel = ZONE::GET_NAME_OF_ZONE(destination.x, destination.y, destination.z);
+		if (IsValidLocationName(zoneLabel))
+		{
+			const auto zoneName = HUD::GET_FILENAME_FOR_AUDIO_CONVERSATION(zoneLabel);
+			if (IsValidLocationName(zoneName))
+				return zoneName;
+		}
+
+		return "Waypoint";
+	}
+
+	static void ShowStartNotification(std::string_view startMessage, std::string_view destination)
+	{
+		const auto message = std::format(
+		    "{}~n~Style: {}~n~Destination: {}~n~Cruise speed: {} km/h",
+		    startMessage,
+		    GetDrivingStyleName(GetDrivingStyle()),
+		    destination,
+		    GetCruiseSpeedKph());
+
+		HUD::SET_TEXT_OUTLINE();
+		HUD::BEGIN_TEXT_COMMAND_THEFEED_POST("STRING");
+		HUD::ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME(message.c_str());
+		HUD::END_TEXT_COMMAND_THEFEED_POST_TICKER(false, false);
+	}
+
+	struct NavigationTargetSnapshot
+	{
+		bool m_HasTrackedTarget = false;
+		NavigationTarget m_TrackedTarget{};
+		bool m_HasPreferredTarget = false;
+		NavigationTarget m_PreferredTarget{};
+	};
+
+	static constexpr int GetTargetPriority(NavigationTargetSource source)
+	{
+		switch (source)
+		{
+		case NavigationTargetSource::UserWaypoint: return 2;
+		case NavigationTargetSource::MissionObjective: return 1;
+		default: return 0;
+		}
+	}
+
+	static bool TryGetUserWaypoint(NavigationTarget& target)
+	{
+		if (!HUD::IS_WAYPOINT_ACTIVE())
+			return false;
+
+		const auto blip = HUD::GET_CLOSEST_BLIP_INFO_ID(HUD::GET_WAYPOINT_BLIP_ENUM_ID());
+		if (!HUD::DOES_BLIP_EXIST(blip))
+			return false;
+
+		target.m_Source = NavigationTargetSource::UserWaypoint;
+		target.m_BlipHandle = blip;
+		target.m_Position = HUD::GET_BLIP_COORDS(blip);
+		return true;
+	}
+
+	static bool IsYellowMissionColour(Blip blip)
+	{
+		const auto blipColour = HUD::GET_BLIP_COLOUR(blip);
+		if (std::find(
+		        yellow_mission_blip_colours.begin(),
+		        yellow_mission_blip_colours.end(),
+		        blipColour)
+		    != yellow_mission_blip_colours.end())
+			return true;
+
+		const auto hudColour = static_cast<HudColor>(HUD::GET_BLIP_HUD_COLOUR(blip));
+		return hudColour == HudColor::HUD_COLOUR_YELLOW
+		    || hudColour == HudColor::HUD_COLOUR_YELLOWLIGHT
+		    || hudColour == HudColor::HUD_COLOUR_YELLOWDARK
+		    || hudColour == HudColor::HUD_COLOUR_OBJECTIVE_ROUTE;
+	}
+
+	static bool IsMissionObjectiveBlip(Blip blip, BlipSprite sprite)
+	{
+		if (!HUD::DOES_BLIP_HAVE_GPS_ROUTE(blip))
+			return false;
+
+		return sprite == BlipSprite::RADAR_OBJECTIVE_YELLOW || IsYellowMissionColour(blip);
+	}
+
+	static NavigationTargetSnapshot GetNavigationTargets(
+	    const rage::fvector3& vehiclePosition,
+	    const NavigationTarget& trackedTarget)
+	{
+		NavigationTargetSnapshot snapshot;
+		NavigationTarget userWaypoint;
+		const auto hasUserWaypoint = TryGetUserWaypoint(userWaypoint);
+
+		static constexpr std::array missionSprites = {
+		    BlipSprite::RADAR_LEVEL,
+		    BlipSprite::RADAR_HIGHER,
+		    BlipSprite::RADAR_LOWER,
+		    BlipSprite::RADAR_OBJECTIVE_YELLOW};
+
+		NavigationTarget closestMissionTarget;
+		NavigationTarget replacementMissionTarget;
+		NavigationTarget exactMissionTarget;
+		float closestMissionDistanceSquared = std::numeric_limits<float>::max();
+		float replacementDistanceSquared = std::numeric_limits<float>::max();
+		std::size_t closestMissionSpriteIndex = missionSprites.size();
+		std::size_t replacementSpriteIndex = missionSprites.size();
+		bool hasClosestMissionTarget = false;
+		bool hasReplacementMissionTarget = false;
+		bool hasExactMissionTarget = false;
+
+		for (std::size_t spriteIndex = 0; spriteIndex < missionSprites.size(); ++spriteIndex)
+		{
+			const auto sprite = missionSprites[spriteIndex];
+			const auto spriteId = static_cast<int>(sprite);
+			for (auto blip = HUD::GET_FIRST_BLIP_INFO_ID(spriteId);
+			    HUD::DOES_BLIP_EXIST(blip);
+			    blip = HUD::GET_NEXT_BLIP_INFO_ID(spriteId))
+			{
+				if (!IsMissionObjectiveBlip(blip, sprite))
+					continue;
+
+				NavigationTarget candidate{
+				    NavigationTargetSource::MissionObjective,
+				    blip,
+				    HUD::GET_BLIP_COORDS(blip)};
+				const auto vehicleDistanceSquared = DistanceSquared2D(vehiclePosition, candidate.m_Position);
+				if (!hasClosestMissionTarget
+				    || vehicleDistanceSquared < closestMissionDistanceSquared
+				    || (vehicleDistanceSquared == closestMissionDistanceSquared
+				        && spriteIndex == closestMissionSpriteIndex
+				        && candidate.m_BlipHandle < closestMissionTarget.m_BlipHandle))
+				{
+					closestMissionTarget = candidate;
+					closestMissionDistanceSquared = vehicleDistanceSquared;
+					closestMissionSpriteIndex = spriteIndex;
+					hasClosestMissionTarget = true;
+				}
+
+				if (trackedTarget.m_Source != NavigationTargetSource::MissionObjective)
+					continue;
+
+				if (candidate.m_BlipHandle == trackedTarget.m_BlipHandle)
+				{
+					exactMissionTarget = candidate;
+					hasExactMissionTarget = true;
+					continue;
+				}
+
+				const auto replacementDistance = DistanceSquared2D(
+				    trackedTarget.m_Position,
+				    candidate.m_Position);
+				if (replacementDistance <= target_move_threshold_squared
+				    && (!hasReplacementMissionTarget
+				        || replacementDistance < replacementDistanceSquared
+				        || (replacementDistance == replacementDistanceSquared
+				            && spriteIndex == replacementSpriteIndex
+				            && candidate.m_BlipHandle < replacementMissionTarget.m_BlipHandle)))
+				{
+					replacementMissionTarget = candidate;
+					replacementDistanceSquared = replacementDistance;
+					replacementSpriteIndex = spriteIndex;
+					hasReplacementMissionTarget = true;
+				}
+			}
+		}
+
+		if (trackedTarget.m_Source == NavigationTargetSource::UserWaypoint && hasUserWaypoint)
+		{
+			snapshot.m_HasTrackedTarget = true;
+			snapshot.m_TrackedTarget = userWaypoint;
+		}
+		else if (trackedTarget.m_Source == NavigationTargetSource::MissionObjective)
+		{
+			if (hasExactMissionTarget)
+			{
+				snapshot.m_HasTrackedTarget = true;
+				snapshot.m_TrackedTarget = exactMissionTarget;
+			}
+			else if (hasReplacementMissionTarget)
+			{
+				snapshot.m_HasTrackedTarget = true;
+				snapshot.m_TrackedTarget = replacementMissionTarget;
+			}
+		}
+
+		if (hasUserWaypoint)
+		{
+			snapshot.m_HasPreferredTarget = true;
+			snapshot.m_PreferredTarget = userWaypoint;
+		}
+		else if (trackedTarget.m_Source == NavigationTargetSource::MissionObjective
+		    && snapshot.m_HasTrackedTarget)
+		{
+			snapshot.m_HasPreferredTarget = true;
+			snapshot.m_PreferredTarget = snapshot.m_TrackedTarget;
+		}
+		else if (hasClosestMissionTarget)
+		{
+			snapshot.m_HasPreferredTarget = true;
+			snapshot.m_PreferredTarget = closestMissionTarget;
+		}
+
+		return snapshot;
+	}
+
+	static bool TryResolveRoadTarget(const Vector3& waypoint, Vector3& roadTarget)
+	{
+		roadTarget = waypoint;
+		float heading = 0.0f;
+		return PATH::GET_CLOSEST_VEHICLE_NODE_WITH_HEADING(
+		    waypoint.x,
+		    waypoint.y,
+		    waypoint.z,
+		    &roadTarget,
+		    &heading,
+		    1,
+		    3.0f,
+		    0.0f);
+	}
+
+	Coordinator& Coordinator::GetInstance()
+	{
+		static Coordinator instance;
+		return instance;
+	}
+
+	SessionToken Coordinator::ClaimImpl(Owner owner, std::function<void()> cleanup)
+	{
+		if (m_Cleanup)
+		{
+			auto previousCleanup = std::move(m_Cleanup);
+			m_Cleanup = {};
+			previousCleanup();
+		}
+
+		m_Owner = owner;
+		m_Cleanup = std::move(cleanup);
+		return {owner, ++m_Generation};
+	}
+
+	bool Coordinator::OwnsImpl(SessionToken token) const
+	{
+		return token.m_Owner != Owner::None
+		    && token.m_Owner == m_Owner
+		    && token.m_Generation == m_Generation;
+	}
+
+	void Coordinator::ReleaseImpl(SessionToken token)
+	{
+		if (!OwnsImpl(token))
+			return;
+
+		auto cleanup = std::move(m_Cleanup);
+		m_Cleanup = {};
+		m_Owner = Owner::None;
+		++m_Generation;
+		if (cleanup)
+			cleanup();
+	}
+
+	SessionToken Coordinator::Claim(Owner owner, std::function<void()> cleanup)
+	{
+		return GetInstance().ClaimImpl(owner, std::move(cleanup));
+	}
+
+	bool Coordinator::Owns(SessionToken token)
+	{
+		return GetInstance().OwnsImpl(token);
+	}
+
+	void Coordinator::Release(SessionToken token)
+	{
+		GetInstance().ReleaseImpl(token);
+	}
+
+	Owner Coordinator::GetOwner()
+	{
+		return GetInstance().m_Owner;
+	}
+
+	bool RoadDriveController::IsNearStoredDestination(Vehicle vehicle, float distanceSquared) const
+	{
+		const auto position = vehicle.GetPosition();
+		return DistanceSquared2D(position, m_Target.m_Position) <= distanceSquared
+		    || DistanceSquared2D(position, m_RoadTarget) <= distanceSquared;
+	}
+
+	bool RoadDriveController::IsNearRoadTarget(Vehicle vehicle) const
+	{
+		const auto position = vehicle.GetPosition();
+		if (DistanceSquared2D(position, m_RoadTarget) > arrival_distance_squared)
+			return false;
+
+		return !m_HasResolvedRoadTarget
+		    || std::abs(position.z - m_RoadTarget.z) <= arrival_height_threshold;
+	}
+
+	void RoadDriveController::StopBringingToHalt()
+	{
+		if (!m_IsBringingToHalt)
+			return;
+
+		if (m_VehicleHandle && ENTITY::DOES_ENTITY_EXIST(m_VehicleHandle))
+			VEHICLE::STOP_BRINGING_VEHICLE_TO_HALT(m_VehicleHandle);
+
+		m_IsBringingToHalt = false;
+	}
+
+	void RoadDriveController::ClearTask(bool clearPedTask, bool clearVehicleTask)
+	{
+		StopBringingToHalt();
+
+		if (m_HasTask && clearPedTask && m_DriverHandle && ENTITY::DOES_ENTITY_EXIST(m_DriverHandle))
+		{
+			TASK::CLEAR_PED_TASKS(m_DriverHandle);
+			PED::SET_PED_KEEP_TASK(m_DriverHandle, false);
+		}
+
+		if (m_HasTask && clearVehicleTask && m_VehicleHandle && ENTITY::DOES_ENTITY_EXIST(m_VehicleHandle))
+			TASK::CLEAR_PRIMARY_VEHICLE_TASK(m_VehicleHandle);
+
+		m_Mode = Mode::Idle;
+		m_DriverHandle = 0;
+		m_VehicleHandle = 0;
+		m_LastSpeedKph = -1;
+		m_LastDrivingStyle = -1;
+		m_Target = {};
+		m_RoadTarget = {};
+		m_TargetLostAt = {};
+		m_HasTask = false;
+		m_HasResolvedRoadTarget = false;
+		m_ArrivalLatched = false;
+		m_IsBringingToHalt = false;
+	}
+
+	void RoadDriveController::AssignVehicle(Ped driver, Vehicle vehicle)
+	{
+		m_DriverHandle = driver.GetHandle();
+		m_VehicleHandle = vehicle.GetHandle();
+	}
+
+	void RoadDriveController::StartNavigationTask(
+	    Ped driver,
+	    Vehicle vehicle,
+	    const NavigationTarget& target,
+	    std::string_view startMessage)
+	{
+		const auto isInitialTask = !m_HasTask;
+		StopBringingToHalt();
+		AssignVehicle(driver, vehicle);
+		m_Target = target;
+		m_HasResolvedRoadTarget = TryResolveRoadTarget(target.m_Position, m_RoadTarget);
+		m_TargetLostAt = {};
+		m_ArrivalLatched = false;
+		m_LastSpeedKph = GetCruiseSpeedKph();
+		m_LastDrivingStyle = GetDrivingStyle();
+
+		PED::SET_PED_KEEP_TASK(m_DriverHandle, true);
+		TASK::TASK_VEHICLE_DRIVE_TO_COORD_LONGRANGE(
+		    m_DriverHandle,
+		    m_VehicleHandle,
+		    m_RoadTarget.x,
+		    m_RoadTarget.y,
+		    m_RoadTarget.z,
+		    GetCruiseSpeed(),
+		    ResolveDrivingStyle(m_LastDrivingStyle),
+		    stopping_range);
+
+		m_Mode = Mode::Navigation;
+		m_HasTask = true;
+		if (isInitialTask)
+			ShowStartNotification(startMessage, GetDestinationName(target.m_Position));
+	}
+
+	void RoadDriveController::StartWanderTask(Ped driver, Vehicle vehicle, std::string_view startMessage)
+	{
+		const auto isInitialTask = !m_HasTask;
+		StopBringingToHalt();
+		AssignVehicle(driver, vehicle);
+		m_Target = {};
+		m_RoadTarget = {};
+		m_TargetLostAt = {};
+		m_ArrivalLatched = false;
+		m_HasResolvedRoadTarget = false;
+		m_LastSpeedKph = GetCruiseSpeedKph();
+		m_LastDrivingStyle = GetDrivingStyle();
+
+		PED::SET_PED_KEEP_TASK(m_DriverHandle, true);
+		TASK::TASK_VEHICLE_DRIVE_WANDER(
+		    m_DriverHandle,
+		    m_VehicleHandle,
+		    GetCruiseSpeed(),
+		    ResolveDrivingStyle(m_LastDrivingStyle));
+
+		m_Mode = Mode::Wander;
+		m_HasTask = true;
+		if (isInitialTask)
+			ShowStartNotification(startMessage, "Roaming");
+	}
+
+	void RoadDriveController::EnterArrived(Vehicle vehicle)
+	{
+		if (m_Mode == Mode::Arrived)
+			return;
+
+		m_Mode = Mode::Arrived;
+		TASK::SET_DRIVE_TASK_CRUISE_SPEED(m_DriverHandle, 0.0f);
+		vehicle.BringToHalt(5.0f, 1);
+		m_IsBringingToHalt = true;
+	}
+
+	RouteResult RoadDriveController::Tick(Ped driver, Vehicle vehicle, std::string_view startMessage)
+	{
+		if (m_HasTask && (m_DriverHandle != driver.GetHandle() || m_VehicleHandle != vehicle.GetHandle()))
+			ClearTask();
+
+		const auto speedChanged = m_LastSpeedKph != GetCruiseSpeedKph();
+		const auto styleChanged = m_LastDrivingStyle != GetDrivingStyle();
+		auto targets = GetNavigationTargets(vehicle.GetPosition(), m_Target);
+		const auto hasStoredNavigationTask = m_Mode == Mode::Navigation
+		    || m_Mode == Mode::TargetLost
+		    || m_Mode == Mode::Arrived;
+
+		if (hasStoredNavigationTask
+		    && targets.m_HasPreferredTarget
+		    && GetTargetPriority(targets.m_PreferredTarget.m_Source) > GetTargetPriority(m_Target.m_Source))
+		{
+			if (m_Mode == Mode::Arrived
+			    || DistanceSquared2D(m_Target.m_Position, targets.m_PreferredTarget.m_Position)
+			        > target_move_threshold_squared)
+			{
+				StartNavigationTask(driver, vehicle, targets.m_PreferredTarget, startMessage);
+				return RouteResult::Driving;
+			}
+
+			m_Target.m_Source = targets.m_PreferredTarget.m_Source;
+			m_Target.m_BlipHandle = targets.m_PreferredTarget.m_BlipHandle;
+			targets.m_HasTrackedTarget = true;
+			targets.m_TrackedTarget = targets.m_PreferredTarget;
+		}
+
+		if (hasStoredNavigationTask
+		    && targets.m_HasTrackedTarget
+		    && targets.m_TrackedTarget.m_Source == m_Target.m_Source)
+		{
+			m_Target.m_BlipHandle = targets.m_TrackedTarget.m_BlipHandle;
+			if (DistanceSquared2D(m_Target.m_Position, targets.m_TrackedTarget.m_Position)
+			    > target_move_threshold_squared)
+			{
+				StartNavigationTask(driver, vehicle, targets.m_TrackedTarget, startMessage);
+				return RouteResult::Driving;
+			}
+		}
+
+		if (m_Mode == Mode::Arrived)
+		{
+			m_LastSpeedKph = GetCruiseSpeedKph();
+			m_LastDrivingStyle = GetDrivingStyle();
+			if (vehicle.GetSpeed() <= arrival_speed_threshold
+			    || VEHICLE::IS_VEHICLE_STOPPED(vehicle.GetHandle()))
+				return RouteResult::DestinationReached;
+
+			return RouteResult::Driving;
+		}
+
+		if ((m_Mode == Mode::Navigation || m_Mode == Mode::TargetLost)
+		    && IsNearRoadTarget(vehicle))
+		{
+			m_LastSpeedKph = GetCruiseSpeedKph();
+			m_LastDrivingStyle = GetDrivingStyle();
+			EnterArrived(vehicle);
+			if (vehicle.GetSpeed() <= arrival_speed_threshold
+			    || VEHICLE::IS_VEHICLE_STOPPED(vehicle.GetHandle()))
+				return RouteResult::DestinationReached;
+
+			return RouteResult::Driving;
+		}
+
+		if (!targets.m_HasTrackedTarget && m_Mode == Mode::Navigation)
+		{
+			if (IsNearStoredDestination(vehicle, target_loss_arrival_distance_squared))
+			{
+				m_Mode = Mode::TargetLost;
+				m_TargetLostAt = std::chrono::steady_clock::now();
+				m_ArrivalLatched = true;
+			}
+			else if (targets.m_HasPreferredTarget)
+			{
+				StartNavigationTask(driver, vehicle, targets.m_PreferredTarget, startMessage);
+				return RouteResult::Driving;
+			}
+			else
+			{
+				m_Mode = Mode::TargetLost;
+				m_TargetLostAt = std::chrono::steady_clock::now();
+				m_ArrivalLatched = false;
+			}
+		}
+
+		if (m_Mode == Mode::TargetLost)
+		{
+			if (targets.m_HasTrackedTarget)
+			{
+				m_Mode = Mode::Navigation;
+				m_TargetLostAt = {};
+				m_ArrivalLatched = false;
+			}
+			else
+			{
+				if (!m_ArrivalLatched && targets.m_HasPreferredTarget)
+				{
+					StartNavigationTask(driver, vehicle, targets.m_PreferredTarget, startMessage);
+					return RouteResult::Driving;
+				}
+
+				if (!m_ArrivalLatched
+				    && std::chrono::steady_clock::now() - m_TargetLostAt >= target_loss_grace_period)
+				{
+					StartWanderTask(driver, vehicle, startMessage);
+					return RouteResult::Driving;
+				}
+
+				if (speedChanged)
+				{
+					TASK::SET_DRIVE_TASK_CRUISE_SPEED(m_DriverHandle, GetCruiseSpeed());
+					m_LastSpeedKph = GetCruiseSpeedKph();
+				}
+
+				if (styleChanged)
+				{
+					m_LastDrivingStyle = GetDrivingStyle();
+					TASK::SET_DRIVE_TASK_DRIVING_STYLE(
+					    m_DriverHandle,
+					    ResolveDrivingStyle(m_LastDrivingStyle));
+				}
+
+				return RouteResult::Driving;
+			}
+		}
+
+		if (targets.m_HasPreferredTarget)
+		{
+			const auto targetChanged = m_Mode == Mode::Idle || m_Mode == Mode::Wander;
+			if (targetChanged)
+			{
+				StartNavigationTask(driver, vehicle, targets.m_PreferredTarget, startMessage);
+				return RouteResult::Driving;
+			}
+
+			if (styleChanged && m_Mode == Mode::Navigation)
+			{
+				StartNavigationTask(
+				    driver,
+				    vehicle,
+				    targets.m_HasTrackedTarget ? targets.m_TrackedTarget : targets.m_PreferredTarget,
+				    startMessage);
+				return RouteResult::Driving;
+			}
+
+			if (speedChanged && m_HasTask)
+			{
+				TASK::SET_DRIVE_TASK_CRUISE_SPEED(m_DriverHandle, GetCruiseSpeed());
+				m_LastSpeedKph = GetCruiseSpeedKph();
+			}
+
+			return RouteResult::Driving;
+		}
+
+		if (m_Mode != Mode::Wander || styleChanged)
+		{
+			StartWanderTask(driver, vehicle, startMessage);
+			return RouteResult::Driving;
+		}
+
+		if (speedChanged)
+		{
+			TASK::SET_DRIVE_TASK_CRUISE_SPEED(m_DriverHandle, GetCruiseSpeed());
+			m_LastSpeedKph = GetCruiseSpeedKph();
+		}
+
+		return RouteResult::Driving;
+	}
+
+	bool IsSupportedRoadVehicle(Vehicle vehicle)
+	{
+		const auto model = ENTITY::GET_ENTITY_MODEL(vehicle.GetHandle());
+		return VEHICLE::IS_THIS_MODEL_A_CAR(model)
+		    || VEHICLE::IS_THIS_MODEL_A_BIKE(model)
+		    || VEHICLE::IS_THIS_MODEL_A_BICYCLE(model)
+		    || VEHICLE::IS_THIS_MODEL_A_QUADBIKE(model);
+	}
+
+	bool IsSupportedNpcVehicle(Vehicle vehicle)
+	{
+		return VEHICLE::IS_THIS_MODEL_A_CAR(ENTITY::GET_ENTITY_MODEL(vehicle.GetHandle()));
+	}
+
+	int GetCruiseSpeedKph()
+	{
+		return _AutoDriveSpeed.GetState();
+	}
+
+	int GetDrivingStyle()
+	{
+		return _AutoDriveStyle.GetState();
+	}
+}

--- a/src/game/features/vehicle/AutoDriveShared.cpp
+++ b/src/game/features/vehicle/AutoDriveShared.cpp
@@ -441,6 +441,11 @@ namespace YimMenu::Features::AutoDriveInternal
 		m_IsBringingToHalt = false;
 	}
 
+	bool RoadDriveController::HasTask() const
+	{
+		return m_HasTask;
+	}
+
 	void RoadDriveController::AssignVehicle(Ped driver, Vehicle vehicle)
 	{
 		m_DriverHandle = driver.GetHandle();

--- a/src/game/features/vehicle/AutoDriveShared.cpp
+++ b/src/game/features/vehicle/AutoDriveShared.cpp
@@ -4,9 +4,7 @@
 #include "core/commands/ListCommand.hpp"
 #include "game/gta/Natives.hpp"
 #include "types/blip/BlipSprite.hpp"
-#include "types/script/HudColor.hpp"
 
-#include <algorithm>
 #include <array>
 #include <cmath>
 #include <format>
@@ -23,7 +21,6 @@ namespace YimMenu::Features::AutoDriveInternal
 	static constexpr int aggressive_driving_flags = 1074529087;
 	static constexpr int reckless_driving_style = 1074529086;
 	static constexpr float target_move_threshold_squared = 25.0f;
-	static constexpr std::array yellow_mission_blip_colours = {5, 16, 20, 28, 33, 60, 66};
 
 	static IntCommand _AutoDriveSpeed{
 	    "autodrivespeed",
@@ -146,7 +143,7 @@ namespace YimMenu::Features::AutoDriveInternal
 		switch (source)
 		{
 		case NavigationTargetSource::UserWaypoint: return 2;
-		case NavigationTargetSource::MissionObjective: return 1;
+		case NavigationTargetSource::GpsRoute: return 1;
 		default: return 0;
 		}
 	}
@@ -166,29 +163,9 @@ namespace YimMenu::Features::AutoDriveInternal
 		return true;
 	}
 
-	static bool IsYellowMissionColour(Blip blip)
+	static bool IsGpsRouteBlip(Blip blip)
 	{
-		const auto blipColour = HUD::GET_BLIP_COLOUR(blip);
-		if (std::find(
-		        yellow_mission_blip_colours.begin(),
-		        yellow_mission_blip_colours.end(),
-		        blipColour)
-		    != yellow_mission_blip_colours.end())
-			return true;
-
-		const auto hudColour = static_cast<HudColor>(HUD::GET_BLIP_HUD_COLOUR(blip));
-		return hudColour == HudColor::HUD_COLOUR_YELLOW
-		    || hudColour == HudColor::HUD_COLOUR_YELLOWLIGHT
-		    || hudColour == HudColor::HUD_COLOUR_YELLOWDARK
-		    || hudColour == HudColor::HUD_COLOUR_OBJECTIVE_ROUTE;
-	}
-
-	static bool IsMissionObjectiveBlip(Blip blip, BlipSprite sprite)
-	{
-		if (!HUD::DOES_BLIP_HAVE_GPS_ROUTE(blip))
-			return false;
-
-		return sprite == BlipSprite::RADAR_OBJECTIVE_YELLOW || IsYellowMissionColour(blip);
+		return HUD::DOES_BLIP_EXIST(blip) && HUD::DOES_BLIP_HAVE_GPS_ROUTE(blip);
 	}
 
 	static NavigationTargetSnapshot GetNavigationTargets(
@@ -199,58 +176,61 @@ namespace YimMenu::Features::AutoDriveInternal
 		NavigationTarget userWaypoint;
 		const auto hasUserWaypoint = TryGetUserWaypoint(userWaypoint);
 
-		static constexpr std::array missionSprites = {
+		static constexpr std::array gpsRouteSprites = {
 		    BlipSprite::RADAR_LEVEL,
 		    BlipSprite::RADAR_HIGHER,
 		    BlipSprite::RADAR_LOWER,
+		    BlipSprite::RADAR_OBJECTIVE_BLUE,
+		    BlipSprite::RADAR_OBJECTIVE_GREEN,
+		    BlipSprite::RADAR_OBJECTIVE_RED,
 		    BlipSprite::RADAR_OBJECTIVE_YELLOW};
 
-		NavigationTarget closestMissionTarget;
-		NavigationTarget replacementMissionTarget;
-		NavigationTarget exactMissionTarget;
-		float closestMissionDistanceSquared = std::numeric_limits<float>::max();
+		NavigationTarget closestGpsTarget;
+		NavigationTarget replacementGpsTarget;
+		NavigationTarget exactGpsTarget;
+		float closestGpsDistanceSquared = std::numeric_limits<float>::max();
 		float replacementDistanceSquared = std::numeric_limits<float>::max();
-		std::size_t closestMissionSpriteIndex = missionSprites.size();
-		std::size_t replacementSpriteIndex = missionSprites.size();
-		bool hasClosestMissionTarget = false;
-		bool hasReplacementMissionTarget = false;
-		bool hasExactMissionTarget = false;
+		std::size_t closestGpsSpriteIndex = gpsRouteSprites.size();
+		std::size_t replacementSpriteIndex = gpsRouteSprites.size();
+		bool hasClosestGpsTarget = false;
+		bool hasReplacementGpsTarget = false;
+		bool hasExactGpsTarget = false;
 
-		for (std::size_t spriteIndex = 0; spriteIndex < missionSprites.size(); ++spriteIndex)
+		for (std::size_t spriteIndex = 0; spriteIndex < gpsRouteSprites.size(); ++spriteIndex)
 		{
-			const auto sprite = missionSprites[spriteIndex];
+			const auto sprite = gpsRouteSprites[spriteIndex];
 			const auto spriteId = static_cast<int>(sprite);
 			for (auto blip = HUD::GET_FIRST_BLIP_INFO_ID(spriteId);
 			    HUD::DOES_BLIP_EXIST(blip);
 			    blip = HUD::GET_NEXT_BLIP_INFO_ID(spriteId))
 			{
-				if (!IsMissionObjectiveBlip(blip, sprite))
+				if (!IsGpsRouteBlip(blip))
 					continue;
 
 				NavigationTarget candidate{
-				    NavigationTargetSource::MissionObjective,
+				    NavigationTargetSource::GpsRoute,
 				    blip,
 				    HUD::GET_BLIP_COORDS(blip)};
 				const auto vehicleDistanceSquared = DistanceSquared2D(vehiclePosition, candidate.m_Position);
-				if (!hasClosestMissionTarget
-				    || vehicleDistanceSquared < closestMissionDistanceSquared
-				    || (vehicleDistanceSquared == closestMissionDistanceSquared
-				        && spriteIndex == closestMissionSpriteIndex
-				        && candidate.m_BlipHandle < closestMissionTarget.m_BlipHandle))
+				if (!hasClosestGpsTarget
+				    || vehicleDistanceSquared < closestGpsDistanceSquared
+				    || (vehicleDistanceSquared == closestGpsDistanceSquared
+				        && spriteIndex == closestGpsSpriteIndex
+				        && candidate.m_BlipHandle < closestGpsTarget.m_BlipHandle))
 				{
-					closestMissionTarget = candidate;
-					closestMissionDistanceSquared = vehicleDistanceSquared;
-					closestMissionSpriteIndex = spriteIndex;
-					hasClosestMissionTarget = true;
+					closestGpsTarget = candidate;
+					closestGpsDistanceSquared = vehicleDistanceSquared;
+					closestGpsSpriteIndex = spriteIndex;
+					hasClosestGpsTarget = true;
 				}
 
-				if (trackedTarget.m_Source != NavigationTargetSource::MissionObjective)
+				if (trackedTarget.m_Source != NavigationTargetSource::GpsRoute)
 					continue;
 
 				if (candidate.m_BlipHandle == trackedTarget.m_BlipHandle)
 				{
-					exactMissionTarget = candidate;
-					hasExactMissionTarget = true;
+					exactGpsTarget = candidate;
+					hasExactGpsTarget = true;
 					continue;
 				}
 
@@ -258,16 +238,16 @@ namespace YimMenu::Features::AutoDriveInternal
 				    trackedTarget.m_Position,
 				    candidate.m_Position);
 				if (replacementDistance <= target_move_threshold_squared
-				    && (!hasReplacementMissionTarget
+				    && (!hasReplacementGpsTarget
 				        || replacementDistance < replacementDistanceSquared
 				        || (replacementDistance == replacementDistanceSquared
 				            && spriteIndex == replacementSpriteIndex
-				            && candidate.m_BlipHandle < replacementMissionTarget.m_BlipHandle)))
+				            && candidate.m_BlipHandle < replacementGpsTarget.m_BlipHandle)))
 				{
-					replacementMissionTarget = candidate;
+					replacementGpsTarget = candidate;
 					replacementDistanceSquared = replacementDistance;
 					replacementSpriteIndex = spriteIndex;
-					hasReplacementMissionTarget = true;
+					hasReplacementGpsTarget = true;
 				}
 			}
 		}
@@ -277,17 +257,17 @@ namespace YimMenu::Features::AutoDriveInternal
 			snapshot.m_HasTrackedTarget = true;
 			snapshot.m_TrackedTarget = userWaypoint;
 		}
-		else if (trackedTarget.m_Source == NavigationTargetSource::MissionObjective)
+		else if (trackedTarget.m_Source == NavigationTargetSource::GpsRoute)
 		{
-			if (hasExactMissionTarget)
+			if (hasExactGpsTarget)
 			{
 				snapshot.m_HasTrackedTarget = true;
-				snapshot.m_TrackedTarget = exactMissionTarget;
+				snapshot.m_TrackedTarget = exactGpsTarget;
 			}
-			else if (hasReplacementMissionTarget)
+			else if (hasReplacementGpsTarget)
 			{
 				snapshot.m_HasTrackedTarget = true;
-				snapshot.m_TrackedTarget = replacementMissionTarget;
+				snapshot.m_TrackedTarget = replacementGpsTarget;
 			}
 		}
 
@@ -296,16 +276,16 @@ namespace YimMenu::Features::AutoDriveInternal
 			snapshot.m_HasPreferredTarget = true;
 			snapshot.m_PreferredTarget = userWaypoint;
 		}
-		else if (trackedTarget.m_Source == NavigationTargetSource::MissionObjective
+		else if (trackedTarget.m_Source == NavigationTargetSource::GpsRoute
 		    && snapshot.m_HasTrackedTarget)
 		{
 			snapshot.m_HasPreferredTarget = true;
 			snapshot.m_PreferredTarget = snapshot.m_TrackedTarget;
 		}
-		else if (hasClosestMissionTarget)
+		else if (hasClosestGpsTarget)
 		{
 			snapshot.m_HasPreferredTarget = true;
-			snapshot.m_PreferredTarget = closestMissionTarget;
+			snapshot.m_PreferredTarget = closestGpsTarget;
 		}
 
 		return snapshot;

--- a/src/game/features/vehicle/AutoDriveShared.cpp
+++ b/src/game/features/vehicle/AutoDriveShared.cpp
@@ -446,6 +446,26 @@ namespace YimMenu::Features::AutoDriveInternal
 		return m_HasTask;
 	}
 
+	RoadDriveStatus RoadDriveController::GetStatus() const
+	{
+		RoutePhase phase = RoutePhase::Idle;
+		switch (m_Mode)
+		{
+		case Mode::Navigation: phase = RoutePhase::Navigation; break;
+		case Mode::TargetLost: phase = RoutePhase::TargetLost; break;
+		case Mode::Wander: phase = RoutePhase::Wander; break;
+		case Mode::Arrived: phase = RoutePhase::Arrived; break;
+		default: break;
+		}
+
+		return {
+		    phase,
+		    m_Target.m_Source,
+		    m_Target.m_Position,
+		    m_RoadTarget,
+		    m_HasTask};
+	}
+
 	void RoadDriveController::AssignVehicle(Ped driver, Vehicle vehicle)
 	{
 		m_DriverHandle = driver.GetHandle();

--- a/src/game/features/vehicle/AutoDriveShared.hpp
+++ b/src/game/features/vehicle/AutoDriveShared.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "game/gta/Ped.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <string_view>
+
+namespace YimMenu::Features::AutoDriveInternal
+{
+	enum class Owner
+	{
+		None,
+		Player,
+		Npc
+	};
+
+	struct SessionToken
+	{
+		Owner m_Owner = Owner::None;
+		std::uint64_t m_Generation = 0;
+	};
+
+	class Coordinator
+	{
+		Owner m_Owner = Owner::None;
+		std::uint64_t m_Generation = 0;
+		std::function<void()> m_Cleanup;
+
+		static Coordinator& GetInstance();
+
+		SessionToken ClaimImpl(Owner owner, std::function<void()> cleanup);
+		bool OwnsImpl(SessionToken token) const;
+		void ReleaseImpl(SessionToken token);
+
+	public:
+		static SessionToken Claim(Owner owner, std::function<void()> cleanup);
+		static bool Owns(SessionToken token);
+		static void Release(SessionToken token);
+		static Owner GetOwner();
+	};
+
+	enum class RouteResult
+	{
+		Driving,
+		DestinationReached
+	};
+
+	enum class NavigationTargetSource
+	{
+		None,
+		UserWaypoint,
+		MissionObjective
+	};
+
+	struct NavigationTarget
+	{
+		NavigationTargetSource m_Source = NavigationTargetSource::None;
+		Blip m_BlipHandle = 0;
+		Vector3 m_Position{};
+	};
+
+	class RoadDriveController
+	{
+		enum class Mode
+		{
+			Idle,
+			Navigation,
+			TargetLost,
+			Wander,
+			Arrived
+		};
+
+		static constexpr float target_loss_arrival_distance_squared = 2500.0f;
+		static constexpr float arrival_distance_squared = 100.0f;
+		static constexpr float arrival_height_threshold = 5.0f;
+		static constexpr float arrival_speed_threshold = 1.0f;
+		static constexpr auto target_loss_grace_period = std::chrono::seconds(1);
+		static constexpr float stopping_range = 8.0f;
+
+		Mode m_Mode = Mode::Idle;
+		int m_DriverHandle = 0;
+		int m_VehicleHandle = 0;
+		int m_LastSpeedKph = -1;
+		int m_LastDrivingStyle = -1;
+		NavigationTarget m_Target{};
+		Vector3 m_RoadTarget{};
+		std::chrono::steady_clock::time_point m_TargetLostAt{};
+		bool m_HasTask = false;
+		bool m_HasResolvedRoadTarget = false;
+		bool m_ArrivalLatched = false;
+		bool m_IsBringingToHalt = false;
+
+		bool IsNearStoredDestination(Vehicle vehicle, float distanceSquared) const;
+		bool IsNearRoadTarget(Vehicle vehicle) const;
+		void StopBringingToHalt();
+		void AssignVehicle(Ped driver, Vehicle vehicle);
+		void StartNavigationTask(Ped driver, Vehicle vehicle, const NavigationTarget& target, std::string_view startMessage);
+		void StartWanderTask(Ped driver, Vehicle vehicle, std::string_view startMessage);
+		void EnterArrived(Vehicle vehicle);
+
+	public:
+		RouteResult Tick(Ped driver, Vehicle vehicle, std::string_view startMessage);
+		void ClearTask(bool clearPedTask = true, bool clearVehicleTask = true);
+	};
+
+	bool IsSupportedRoadVehicle(Vehicle vehicle);
+	bool IsSupportedNpcVehicle(Vehicle vehicle);
+	int GetCruiseSpeedKph();
+	int GetDrivingStyle();
+}

--- a/src/game/features/vehicle/AutoDriveShared.hpp
+++ b/src/game/features/vehicle/AutoDriveShared.hpp
@@ -51,7 +51,7 @@ namespace YimMenu::Features::AutoDriveInternal
 	{
 		None,
 		UserWaypoint,
-		MissionObjective
+		GpsRoute
 	};
 
 	enum class RoutePhase

--- a/src/game/features/vehicle/AutoDriveShared.hpp
+++ b/src/game/features/vehicle/AutoDriveShared.hpp
@@ -54,11 +54,29 @@ namespace YimMenu::Features::AutoDriveInternal
 		MissionObjective
 	};
 
+	enum class RoutePhase
+	{
+		Idle,
+		Navigation,
+		TargetLost,
+		Wander,
+		Arrived
+	};
+
 	struct NavigationTarget
 	{
 		NavigationTargetSource m_Source = NavigationTargetSource::None;
 		Blip m_BlipHandle = 0;
 		Vector3 m_Position{};
+	};
+
+	struct RoadDriveStatus
+	{
+		RoutePhase m_Phase = RoutePhase::Idle;
+		NavigationTargetSource m_TargetSource = NavigationTargetSource::None;
+		Vector3 m_Target{};
+		Vector3 m_RoadTarget{};
+		bool m_HasTask = false;
 	};
 
 	class RoadDriveController
@@ -104,6 +122,7 @@ namespace YimMenu::Features::AutoDriveInternal
 		RouteResult Tick(Ped driver, Vehicle vehicle, std::string_view startMessage);
 		void ClearTask(bool clearPedTask = true, bool clearVehicleTask = true);
 		bool HasTask() const;
+		RoadDriveStatus GetStatus() const;
 	};
 
 	bool IsSupportedRoadVehicle(Vehicle vehicle);

--- a/src/game/features/vehicle/AutoDriveShared.hpp
+++ b/src/game/features/vehicle/AutoDriveShared.hpp
@@ -103,6 +103,7 @@ namespace YimMenu::Features::AutoDriveInternal
 	public:
 		RouteResult Tick(Ped driver, Vehicle vehicle, std::string_view startMessage);
 		void ClearTask(bool clearPedTask = true, bool clearVehicleTask = true);
+		bool HasTask() const;
 	};
 
 	bool IsSupportedRoadVehicle(Vehicle vehicle);

--- a/src/game/features/vehicle/NpcAutoDrive.cpp
+++ b/src/game/features/vehicle/NpcAutoDrive.cpp
@@ -1,0 +1,385 @@
+#include "AutoDriveShared.hpp"
+
+#include "core/commands/BoolCommand.hpp"
+#include "core/commands/Commands.hpp"
+#include "core/commands/LoopedCommand.hpp"
+#include "core/frontend/Notifications.hpp"
+#include "core/util/Joaat.hpp"
+#include "game/backend/Self.hpp"
+#include "game/gta/Natives.hpp"
+#include "types/ped/PedConfigFlag.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace YimMenu::Features
+{
+	class NpcAutoDrive : public LoopedCommand
+	{
+		enum class FailureReason
+		{
+			None,
+			NoVehicle,
+			PlayerDead,
+			NotDriver,
+			UnsupportedVehicle,
+			NoPassengerSeat,
+			VehicleUndriveable,
+			NoControl
+		};
+
+		static constexpr Hash taxi_driver_model = "s_m_m_gentransport"_J;
+
+		AutoDriveInternal::RoadDriveController m_Route;
+		AutoDriveInternal::SessionToken m_Session;
+		FailureReason m_FailureReason = FailureReason::None;
+		int m_PlayerHandle = 0;
+		int m_VehicleHandle = 0;
+		int m_DriverHandle = 0;
+		std::uint16_t m_DriverNetworkId = 0;
+		bool m_PreviousPreventAutoShuffle = false;
+		bool m_HasSavedPlayerFlag = false;
+
+		static std::optional<int> FindPassengerSeat(Vehicle vehicle)
+		{
+			const auto passengerCount = VEHICLE::GET_VEHICLE_MAX_NUMBER_OF_PASSENGERS(vehicle.GetHandle());
+			for (int seat = 0; seat < passengerCount; ++seat)
+			{
+				if (vehicle.IsSeatFree(seat))
+					return seat;
+			}
+
+			return std::nullopt;
+		}
+
+		void SetFailure(FailureReason reason, std::string_view message = {})
+		{
+			if (reason == m_FailureReason)
+				return;
+
+			m_FailureReason = reason;
+			if (reason != FailureReason::None)
+				Notifications::Show("NPC Auto Drive", std::string(message), NotificationType::Warning);
+		}
+
+		bool IsOwnedDriver(Ped driver) const
+		{
+			if (!driver
+			    || driver.GetHandle() != m_DriverHandle
+			    || !ENTITY::IS_ENTITY_A_PED(driver.GetHandle())
+			    || PED::IS_PED_A_PLAYER(driver.GetHandle())
+			    || ENTITY::GET_ENTITY_MODEL(driver.GetHandle()) != taxi_driver_model)
+				return false;
+
+			return !m_DriverNetworkId
+			    || (driver.IsNetworked() && driver.GetNetworkObjectId() == m_DriverNetworkId);
+		}
+
+		void ResetSessionState()
+		{
+			m_PlayerHandle = 0;
+			m_VehicleHandle = 0;
+			m_DriverHandle = 0;
+			m_DriverNetworkId = 0;
+			m_PreviousPreventAutoShuffle = false;
+			m_HasSavedPlayerFlag = false;
+			m_FailureReason = FailureReason::None;
+		}
+
+		void ClearOwnedSession()
+		{
+			Vehicle vehicle(0);
+			if (m_VehicleHandle && ENTITY::DOES_ENTITY_EXIST(m_VehicleHandle))
+				vehicle = Vehicle(m_VehicleHandle);
+
+			Ped driver(0);
+			const auto hasOwnedDriver = m_DriverHandle
+			    && ENTITY::DOES_ENTITY_EXIST(m_DriverHandle)
+			    && IsOwnedDriver(Ped(m_DriverHandle));
+			if (hasOwnedDriver)
+				driver = Ped(m_DriverHandle);
+
+			const auto ownsDriverSeat = vehicle
+			    && driver
+			    && VEHICLE::GET_PED_IN_VEHICLE_SEAT(vehicle.GetHandle(), -1, false) == driver.GetHandle();
+			const auto driverSeatIsFree = vehicle
+			    && VEHICLE::IS_VEHICLE_SEAT_FREE(vehicle.GetHandle(), -1, false);
+			const auto canControlDriver = driver && driver.RequestControl(0);
+			const auto canControlVehicle = vehicle && vehicle.RequestControl(0);
+			const auto canClearVehicleTask = canControlVehicle && (ownsDriverSeat || driverSeatIsFree);
+			m_Route.ClearTask(canControlDriver, canClearVehicleTask);
+
+			Ped player(0);
+			if (m_PlayerHandle && ENTITY::DOES_ENTITY_EXIST(m_PlayerHandle) && PED::IS_PED_A_PLAYER(m_PlayerHandle))
+				player = Ped(m_PlayerHandle);
+
+			const auto playerStillInVehicle = player
+			    && vehicle
+			    && PED::IS_PED_IN_VEHICLE(player.GetHandle(), vehicle.GetHandle(), false);
+			const auto playerCanTakeControl = playerStillInVehicle
+			    && !player.IsDead()
+			    && VEHICLE::IS_VEHICLE_DRIVEABLE(vehicle.GetHandle(), false);
+			if (!playerCanTakeControl && vehicle && canClearVehicleTask)
+				vehicle.BringToHalt(5.0f, 1);
+
+			if (driver)
+				driver.Delete();
+
+			if (playerCanTakeControl && (driverSeatIsFree || ownsDriverSeat))
+				player.SetInVehicle(vehicle, -1);
+
+			if (player && m_HasSavedPlayerFlag)
+				player.SetConfigFlag(PedConfigFlag::PreventAutoShuffleToDriversSeat, m_PreviousPreventAutoShuffle);
+
+			ResetSessionState();
+		}
+
+		void DisableWithNotification(std::string_view message, NotificationType type = NotificationType::Warning)
+		{
+			AutoDriveInternal::Coordinator::Release(m_Session);
+			if (GetState())
+				SetState(false);
+
+			Notifications::Show("NPC Auto Drive", std::string(message), type);
+		}
+
+		bool ValidateSetupCandidate(Ped player, Vehicle vehicle, std::optional<int>& passengerSeat)
+		{
+			if (!player || !vehicle)
+			{
+				SetFailure(FailureReason::NoVehicle, "Enter the driver seat of a supported car.");
+				return false;
+			}
+
+			if (player.IsDead())
+			{
+				SetFailure(FailureReason::PlayerDead, "NPC Auto Drive is waiting for the player to respawn.");
+				return false;
+			}
+
+			if (VEHICLE::GET_PED_IN_VEHICLE_SEAT(vehicle.GetHandle(), -1, false) != player.GetHandle())
+			{
+				SetFailure(FailureReason::NotDriver, "Move to the driver seat to start NPC Auto Drive.");
+				return false;
+			}
+
+			if (!AutoDriveInternal::IsSupportedNpcVehicle(vehicle))
+			{
+				SetFailure(FailureReason::UnsupportedVehicle, "NPC Auto Drive only supports cars with a passenger seat.");
+				return false;
+			}
+
+			if (!VEHICLE::IS_VEHICLE_DRIVEABLE(vehicle.GetHandle(), false))
+			{
+				SetFailure(FailureReason::VehicleUndriveable, "The current vehicle cannot be driven.");
+				return false;
+			}
+
+			passengerSeat = FindPassengerSeat(vehicle);
+			if (!passengerSeat)
+			{
+				SetFailure(FailureReason::NoPassengerSeat, "NPC Auto Drive requires an empty passenger seat.");
+				return false;
+			}
+
+			if (!vehicle.RequestControl(0))
+			{
+				SetFailure(FailureReason::NoControl, "Waiting for network control of the current vehicle.");
+				return false;
+			}
+
+			SetFailure(FailureReason::None);
+			return true;
+		}
+
+		bool SetupDriver()
+		{
+			auto player = Self::GetPed();
+			auto vehicle = Self::GetVehicle();
+			std::optional<int> passengerSeat;
+			if (!ValidateSetupCandidate(player, vehicle, passengerSeat))
+				return false;
+
+			const auto setupSession = m_Session;
+			const auto playerHandle = player.GetHandle();
+			const auto vehicleHandle = vehicle.GetHandle();
+			auto spawnPosition = vehicle.GetPosition();
+			spawnPosition.z -= 5.0f;
+			auto driver = Ped::Create(taxi_driver_model, spawnPosition, vehicle.GetHeading());
+			if (!driver)
+			{
+				if (AutoDriveInternal::Coordinator::Owns(setupSession) && GetState())
+					DisableWithNotification("Unable to create the NPC driver.");
+				return false;
+			}
+
+			player = Self::GetPed();
+			vehicle = Self::GetVehicle();
+			if (!AutoDriveInternal::Coordinator::Owns(setupSession)
+			    || !GetState()
+			    || !player
+			    || !vehicle
+			    || player.GetHandle() != playerHandle
+			    || vehicle.GetHandle() != vehicleHandle
+			    || VEHICLE::GET_PED_IN_VEHICLE_SEAT(vehicleHandle, -1, false) != playerHandle
+			    || !VEHICLE::IS_VEHICLE_DRIVEABLE(vehicleHandle, false)
+			    || !vehicle.IsSeatFree(*passengerSeat)
+			    || !vehicle.RequestControl(0))
+			{
+				driver.Delete();
+				return false;
+			}
+
+			driver.SetVisible(false);
+			driver.SetCollision(false);
+			driver.SetInvincible(true);
+			driver.SetRagdoll(false);
+			PED::SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(driver.GetHandle(), true);
+			PED::SET_PED_CAN_BE_DRAGGED_OUT(driver.GetHandle(), false);
+			PED::SET_PED_STAY_IN_VEHICLE_WHEN_JACKED(driver.GetHandle(), true);
+			PED::SET_PED_KEEP_TASK(driver.GetHandle(), true);
+			PED::SET_DRIVER_ABILITY(driver.GetHandle(), 1.0f);
+
+			const auto previousPreventAutoShuffle = player.GetConfigFlag(PedConfigFlag::PreventAutoShuffleToDriversSeat);
+			player.SetConfigFlag(PedConfigFlag::PreventAutoShuffleToDriversSeat, true);
+			player.SetInVehicle(vehicle, *passengerSeat);
+			if (VEHICLE::GET_PED_IN_VEHICLE_SEAT(vehicleHandle, *passengerSeat, false) != playerHandle)
+			{
+				player.SetConfigFlag(PedConfigFlag::PreventAutoShuffleToDriversSeat, previousPreventAutoShuffle);
+				driver.Delete();
+				DisableWithNotification("Unable to move the player to a passenger seat.");
+				return false;
+			}
+
+			driver.SetInVehicle(vehicle, -1);
+			if (VEHICLE::GET_PED_IN_VEHICLE_SEAT(vehicleHandle, -1, false) != driver.GetHandle())
+			{
+				driver.Delete();
+				if (VEHICLE::IS_VEHICLE_SEAT_FREE(vehicleHandle, -1, false))
+					player.SetInVehicle(vehicle, -1);
+				player.SetConfigFlag(PedConfigFlag::PreventAutoShuffleToDriversSeat, previousPreventAutoShuffle);
+				DisableWithNotification("Unable to place the NPC in the driver seat.");
+				return false;
+			}
+
+			driver.SetCollision(true);
+			driver.SetVisible(true);
+			m_PlayerHandle = playerHandle;
+			m_VehicleHandle = vehicleHandle;
+			m_DriverHandle = driver.GetHandle();
+			m_DriverNetworkId = driver.GetNetworkObjectId();
+			m_PreviousPreventAutoShuffle = previousPreventAutoShuffle;
+			m_HasSavedPlayerFlag = true;
+			SetFailure(FailureReason::None);
+			return true;
+		}
+
+		bool ValidateActiveSession(Ped player, Vehicle vehicle, Ped driver)
+		{
+			if (!player || player.GetHandle() != m_PlayerHandle || player.IsDead())
+			{
+				DisableWithNotification("NPC Auto Drive disabled because the player is unavailable.");
+				return false;
+			}
+
+			if (!vehicle || vehicle.GetHandle() != m_VehicleHandle
+			    || !PED::IS_PED_IN_VEHICLE(player.GetHandle(), m_VehicleHandle, false))
+			{
+				DisableWithNotification("NPC Auto Drive disabled because the player left the vehicle.");
+				return false;
+			}
+
+			if (!VEHICLE::IS_VEHICLE_DRIVEABLE(vehicle.GetHandle(), false))
+			{
+				DisableWithNotification("NPC Auto Drive disabled because the vehicle is no longer driveable.");
+				return false;
+			}
+
+			if (!IsOwnedDriver(driver) || driver.IsDead()
+			    || VEHICLE::GET_PED_IN_VEHICLE_SEAT(vehicle.GetHandle(), -1, false) != driver.GetHandle())
+			{
+				DisableWithNotification("NPC Auto Drive disabled because the NPC driver is unavailable.");
+				return false;
+			}
+
+			if (!vehicle.RequestControl(0) || !driver.RequestControl(0))
+			{
+				SetFailure(FailureReason::NoControl, "Waiting for network control of the vehicle and NPC driver.");
+				return false;
+			}
+
+			SetFailure(FailureReason::None);
+			return true;
+		}
+
+		virtual void OnEnable() override
+		{
+			auto playerAutoDrive = Commands::GetCommand<BoolCommand>("autodrive"_J);
+			if (AutoDriveInternal::Coordinator::GetOwner() == AutoDriveInternal::Owner::None
+			    && playerAutoDrive
+			    && playerAutoDrive->GetState())
+			{
+				SetState(false);
+				return;
+			}
+
+			m_Session = AutoDriveInternal::Coordinator::Claim(AutoDriveInternal::Owner::Npc, [this] {
+				ClearOwnedSession();
+			});
+
+			if (playerAutoDrive && playerAutoDrive->GetState())
+				playerAutoDrive->SetState(false);
+		}
+
+		virtual void OnTick() override
+		{
+			if (!AutoDriveInternal::Coordinator::Owns(m_Session))
+				return;
+
+			if (!m_DriverHandle)
+			{
+				if (!SetupDriver())
+					return;
+			}
+
+			auto player = Self::GetPed();
+			auto vehicle = Self::GetVehicle();
+			Ped driver(0);
+			if (m_DriverHandle && ENTITY::DOES_ENTITY_EXIST(m_DriverHandle))
+				driver = Ped(m_DriverHandle);
+
+			if (!ValidateActiveSession(player, vehicle, driver))
+				return;
+
+			if (m_Route.Tick(driver, vehicle, "NPC Auto Drive started.") == AutoDriveInternal::RouteResult::DestinationReached)
+			{
+				AutoDriveInternal::Coordinator::Release(m_Session);
+				SetState(false);
+				Notifications::Show(
+				    "NPC Auto Drive",
+				    "Destination reached. NPC Auto Drive disabled; please take control.",
+				    NotificationType::Success);
+			}
+		}
+
+		virtual void OnDisable() override
+		{
+			// A queued disable callback may run after the command has already been re-enabled.
+			if (GetState() && IsReady())
+				return;
+
+			AutoDriveInternal::Coordinator::Release(m_Session);
+			m_FailureReason = FailureReason::None;
+		}
+
+	public:
+		using LoopedCommand::LoopedCommand;
+	};
+
+	static NpcAutoDrive _NpcAutoDrive{
+	    "npcautodrive",
+	    "NPC Auto Drive",
+	    "Moves you to a passenger seat and lets an NPC drive to your waypoint or roam"};
+}

--- a/src/game/features/vehicle/NpcAutoDrive.cpp
+++ b/src/game/features/vehicle/NpcAutoDrive.cpp
@@ -1,4 +1,5 @@
 #include "AutoDriveShared.hpp"
+#include "AutoDriveHudTelemetry.hpp"
 
 #include "core/commands/BoolCommand.hpp"
 #include "core/commands/Commands.hpp"
@@ -90,6 +91,7 @@ namespace YimMenu::Features
 
 		void ClearOwnedSession()
 		{
+			AutoDriveInternal::AutoDriveHudTelemetry::Clear(m_Session);
 			Vehicle vehicle(0);
 			if (m_VehicleHandle && ENTITY::DOES_ENTITY_EXIST(m_VehicleHandle))
 				vehicle = Vehicle(m_VehicleHandle);
@@ -351,9 +353,14 @@ namespace YimMenu::Features
 				driver = Ped(m_DriverHandle);
 
 			if (!ValidateActiveSession(player, vehicle, driver))
+			{
+				AutoDriveInternal::AutoDriveHudTelemetry::Clear(m_Session);
 				return;
+			}
 
-			if (m_Route.Tick(driver, vehicle, "NPC Auto Drive started.") == AutoDriveInternal::RouteResult::DestinationReached)
+			const auto routeResult = m_Route.Tick(driver, vehicle, "NPC Auto Drive started.");
+			AutoDriveInternal::AutoDriveHudTelemetry::Update(m_Session, driver, vehicle, m_Route.GetStatus());
+			if (routeResult == AutoDriveInternal::RouteResult::DestinationReached)
 			{
 				AutoDriveInternal::Coordinator::Release(m_Session);
 				SetState(false);

--- a/src/game/frontend/AutoDriveHUD.cpp
+++ b/src/game/frontend/AutoDriveHUD.cpp
@@ -1,0 +1,356 @@
+#include "AutoDriveHUD.hpp"
+
+#include "game/features/vehicle/AutoDriveHudTelemetry.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <unordered_map>
+#include <vector>
+
+namespace YimMenu
+{
+	using namespace Features::AutoDriveInternal;
+	using namespace std::chrono_literals;
+
+	namespace
+	{
+		constexpr ImU32 kPanel = IM_COL32(15, 22, 31, 224);
+		constexpr ImU32 kPanelBorder = IM_COL32(93, 120, 143, 140);
+		constexpr ImU32 kBlue = IM_COL32(35, 144, 255, 255);
+		constexpr ImU32 kBlueShadow = IM_COL32(3, 25, 48, 230);
+		constexpr ImU32 kLane = IM_COL32(176, 195, 210, 118);
+		constexpr ImU32 kText = IM_COL32(235, 244, 250, 255);
+		constexpr ImU32 kMuted = IM_COL32(143, 163, 178, 255);
+		struct Projection
+		{
+			ImVec2 m_PanelMin{};
+			ImVec2 m_PanelMax{};
+			float m_CenterX = 0.0f;
+			float m_EgoY = 0.0f;
+			float m_RoadTop = 0.0f;
+			float m_Width = 0.0f;
+
+			ImVec2 Project(HudPoint point) const
+			{
+				if (point.m_Y >= 0.0f)
+				{
+					const auto normalized = std::clamp(point.m_Y / 90.0f, 0.0f, 1.0f);
+					const auto depth = std::pow(normalized, 0.72f);
+					const auto horizontalScale = std::lerp(m_Width / 34.0f, m_Width / 120.0f, depth);
+					return {m_CenterX + point.m_X * horizontalScale, m_EgoY - depth * (m_EgoY - m_RoadTop)};
+				}
+
+				const auto behind = std::clamp(-point.m_Y / 30.0f, 0.0f, 1.0f);
+				return {m_CenterX + point.m_X * (m_Width / 34.0f), m_EgoY + behind * (m_PanelMax.y - 18.0f - m_EgoY)};
+			}
+
+			float HorizontalScale(float forward) const
+			{
+				const auto depth = std::pow(std::clamp(std::max(0.0f, forward) / 90.0f, 0.0f, 1.0f), 0.72f);
+				return std::lerp(m_Width / 34.0f, m_Width / 120.0f, depth);
+			}
+
+			float DepthFade(float forward) const
+			{
+				return std::clamp(1.15f - std::max(0.0f, forward) / 120.0f, 0.25f, 1.0f);
+			}
+		};
+
+		struct RenderEntity
+		{
+			HudEntitySnapshot m_Data{};
+			std::chrono::steady_clock::time_point m_LastSeen{};
+		};
+
+		ImU32 WithAlpha(ImU32 color, float alpha)
+		{
+			const auto original = static_cast<float>((color >> IM_COL32_A_SHIFT) & 0xFF) / 255.0f;
+			const auto value = static_cast<ImU32>(std::clamp(original * alpha, 0.0f, 1.0f) * 255.0f);
+			return (color & ~IM_COL32_A_MASK) | (value << IM_COL32_A_SHIFT);
+		}
+
+		const char* PhaseLabel(const AutoDriveHudSnapshot& snapshot)
+		{
+			if (snapshot.m_RouteCalculating)
+				return "CALCULATING";
+			switch (snapshot.m_Phase)
+			{
+			case RoutePhase::Navigation: return "NAVIGATING";
+			case RoutePhase::TargetLost: return "CALCULATING";
+			case RoutePhase::Wander: return "ROAMING";
+			case RoutePhase::Arrived: return "ARRIVING";
+			default: return "STANDBY";
+			}
+		}
+
+		void DrawPolyline(ImDrawList* drawList, const Projection& projection, const std::vector<HudPoint>& points, ImU32 color, float thickness)
+		{
+			std::vector<ImVec2> projected;
+			projected.reserve(points.size());
+			for (const auto& point : points)
+			{
+				if (point.m_Y >= -30.0f && point.m_Y <= 170.0f)
+					projected.push_back(projection.Project(point));
+			}
+			if (projected.size() >= 2)
+				drawList->AddPolyline(projected.data(), static_cast<int>(projected.size()), color, ImDrawFlags_None, thickness);
+		}
+
+		void DrawRoute(ImDrawList* drawList, const Projection& projection, const AutoDriveHudSnapshot& snapshot, float scale)
+		{
+			if (!snapshot.m_RouteReliable || snapshot.m_RoutePoints.size() < 2)
+				return;
+
+			if (!snapshot.m_RoutePredicted)
+			{
+				DrawPolyline(drawList, projection, snapshot.m_RoutePoints, kBlueShadow, 8.0f * scale);
+				DrawPolyline(drawList, projection, snapshot.m_RoutePoints, kBlue, 4.0f * scale);
+				return;
+			}
+
+			for (std::size_t index = 1; index < snapshot.m_RoutePoints.size(); ++index)
+			{
+				if (index % 2 == 0)
+					continue;
+				const auto from = projection.Project(snapshot.m_RoutePoints[index - 1]);
+				const auto to = projection.Project(snapshot.m_RoutePoints[index]);
+				drawList->AddLine(from, to, kBlueShadow, 7.0f * scale);
+				drawList->AddLine(from, to, WithAlpha(kBlue, 0.85f), 3.5f * scale);
+			}
+		}
+
+		void DrawVehicle(ImDrawList* drawList, const Projection& projection, const HudEntitySnapshot& entity, float alpha)
+		{
+			const auto center = projection.Project(entity.m_Position);
+			const auto pxPerMeter = projection.HorizontalScale(entity.m_Position.m_Y);
+			const auto halfWidth = std::clamp(entity.m_Footprint.m_X * pxPerMeter * 0.5f, 2.5f, 15.0f);
+			const auto halfLength = std::clamp(entity.m_Footprint.m_Y * pxPerMeter * 0.38f, 4.0f, 22.0f);
+			const auto direction = ImVec2(std::sin(entity.m_RelativeHeadingRadians), -std::cos(entity.m_RelativeHeadingRadians));
+			const auto right = ImVec2(-direction.y, direction.x);
+			ImVec2 corners[4] = {
+			    center + direction * halfLength + right * halfWidth,
+			    center + direction * halfLength - right * halfWidth,
+			    center - direction * halfLength - right * halfWidth,
+			    center - direction * halfLength + right * halfWidth};
+			drawList->AddConvexPolyFilled(corners, 4, WithAlpha(IM_COL32(166, 181, 193, 245), alpha));
+			drawList->AddPolyline(corners, 4, WithAlpha(IM_COL32(233, 241, 246, 235), alpha), ImDrawFlags_Closed, 1.0f);
+			drawList->AddLine(corners[0], corners[1], WithAlpha(IM_COL32(235, 248, 255, 245), alpha), 2.0f);
+		}
+
+		void DrawPedestrian(ImDrawList* drawList, const Projection& projection, const HudEntitySnapshot& entity, float alpha)
+		{
+			const auto center = projection.Project(entity.m_Position);
+			const auto size = std::clamp(projection.HorizontalScale(entity.m_Position.m_Y) * 0.42f, 2.5f, 7.0f);
+			const auto color = WithAlpha(IM_COL32(255, 184, 88, 255), alpha);
+			drawList->AddCircleFilled({center.x, center.y - size}, size * 0.45f, color);
+			drawList->AddLine({center.x, center.y - size * 0.45f}, {center.x, center.y + size}, color, std::max(1.0f, size * 0.35f));
+		}
+
+		void DrawTrafficLight(ImDrawList* drawList, const Projection& projection, const HudEntitySnapshot& entity, float alpha)
+		{
+			const auto center = projection.Project(entity.m_Position);
+			const auto size = std::clamp(projection.HorizontalScale(entity.m_Position.m_Y) * 0.55f, 3.0f, 9.0f);
+			drawList->AddLine({center.x, center.y + size * 2.5f}, {center.x, center.y}, WithAlpha(IM_COL32(126, 139, 148, 255), alpha), 1.5f);
+			drawList->AddRectFilled({center.x - size * 0.55f, center.y - size * 1.7f}, {center.x + size * 0.55f, center.y}, WithAlpha(IM_COL32(35, 41, 46, 255), alpha), 2.0f);
+			const auto lamp = entity.m_TrafficLightState == TrafficLightState::RedInferred
+			    ? IM_COL32(255, 65, 65, 255)
+			    : IM_COL32(132, 142, 150, 255);
+			drawList->AddCircleFilled({center.x, center.y - size * 1.15f}, size * 0.31f, WithAlpha(lamp, alpha));
+		}
+
+		void DrawObject(ImDrawList* drawList, const Projection& projection, const HudEntitySnapshot& entity, float alpha)
+		{
+			const auto center = projection.Project(entity.m_Position);
+			const auto pxPerMeter = projection.HorizontalScale(entity.m_Position.m_Y);
+			const auto size = std::clamp(pxPerMeter * std::max(0.5f, entity.m_Footprint.m_X), 3.0f, 22.0f);
+			switch (entity.m_Kind)
+			{
+			case HudEntityKind::Cone:
+			{
+				const ImVec2 points[3] = {{center.x, center.y - size}, {center.x - size * 0.65f, center.y + size * 0.55f}, {center.x + size * 0.65f, center.y + size * 0.55f}};
+				drawList->AddConvexPolyFilled(points, 3, WithAlpha(IM_COL32(255, 126, 35, 255), alpha));
+				break;
+			}
+			case HudEntityKind::Barrier:
+				drawList->AddRectFilled({center.x - size, center.y - size * 0.28f}, {center.x + size, center.y + size * 0.28f}, WithAlpha(IM_COL32(242, 153, 53, 255), alpha), 1.0f);
+				drawList->AddLine({center.x - size * 0.7f, center.y + size * 0.25f}, {center.x - size * 0.3f, center.y - size * 0.25f}, WithAlpha(IM_COL32(244, 244, 235, 255), alpha), 2.0f);
+				drawList->AddLine({center.x + size * 0.1f, center.y + size * 0.25f}, {center.x + size * 0.5f, center.y - size * 0.25f}, WithAlpha(IM_COL32(244, 244, 235, 255), alpha), 2.0f);
+				break;
+			case HudEntityKind::Barrel:
+				drawList->AddCircleFilled(center, size * 0.55f, WithAlpha(IM_COL32(210, 116, 46, 255), alpha));
+				break;
+			case HudEntityKind::Bollard:
+				drawList->AddRectFilled({center.x - size * 0.22f, center.y - size}, {center.x + size * 0.22f, center.y + size * 0.35f}, WithAlpha(IM_COL32(224, 208, 93, 255), alpha), size * 0.18f);
+				break;
+			case HudEntityKind::Tree:
+				drawList->AddLine({center.x, center.y + size * 0.7f}, {center.x, center.y}, WithAlpha(IM_COL32(113, 82, 51, 255), alpha), std::max(1.0f, size * 0.2f));
+				drawList->AddCircleFilled({center.x, center.y - size * 0.45f}, size * 0.72f, WithAlpha(IM_COL32(67, 151, 99, 235), alpha));
+				break;
+			default:
+				drawList->AddRectFilled({center.x - size * 0.45f, center.y - size * 0.45f}, {center.x + size * 0.45f, center.y + size * 0.45f}, WithAlpha(IM_COL32(152, 162, 169, 220), alpha), 2.0f);
+				break;
+			}
+		}
+
+		void DrawEntity(ImDrawList* drawList, const Projection& projection, const HudEntitySnapshot& entity, float alpha)
+		{
+			alpha *= projection.DepthFade(entity.m_Position.m_Y);
+			switch (entity.m_Kind)
+			{
+			case HudEntityKind::Vehicle: DrawVehicle(drawList, projection, entity, alpha); break;
+			case HudEntityKind::Pedestrian: DrawPedestrian(drawList, projection, entity, alpha); break;
+			case HudEntityKind::TrafficLight: DrawTrafficLight(drawList, projection, entity, alpha); break;
+			default: DrawObject(drawList, projection, entity, alpha); break;
+			}
+		}
+
+		void DrawEgoVehicle(ImDrawList* drawList, const Projection& projection, float scale)
+		{
+			const auto center = projection.Project({0.0f, 0.0f});
+			const auto halfWidth = 12.0f * scale;
+			const auto halfLength = 22.0f * scale;
+			ImVec2 points[4] = {
+			    {center.x - halfWidth * 0.7f, center.y - halfLength},
+			    {center.x + halfWidth * 0.7f, center.y - halfLength},
+			    {center.x + halfWidth, center.y + halfLength},
+			    {center.x - halfWidth, center.y + halfLength}};
+			drawList->AddConvexPolyFilled(points, 4, IM_COL32(235, 242, 247, 255));
+			drawList->AddPolyline(points, 4, IM_COL32(35, 144, 255, 255), ImDrawFlags_Closed, 2.0f * scale);
+			drawList->AddRectFilled({center.x - halfWidth * 0.55f, center.y - halfLength * 0.45f}, {center.x + halfWidth * 0.55f, center.y + halfLength * 0.1f}, IM_COL32(78, 104, 125, 255), 3.0f * scale);
+		}
+
+		void DrawHeader(ImDrawList* drawList, const Projection& projection, const AutoDriveHudSnapshot& snapshot, float scale)
+		{
+			const auto font = ImGui::GetFont();
+			char speed[16]{};
+			std::snprintf(speed, sizeof(speed), "%d", snapshot.m_SpeedKph);
+			drawList->AddText(font, 30.0f * scale, {projection.m_PanelMin.x + 20.0f * scale, projection.m_PanelMin.y + 14.0f * scale}, kText, speed);
+			drawList->AddText(font, 12.0f * scale, {projection.m_PanelMin.x + 22.0f * scale, projection.m_PanelMin.y + 47.0f * scale}, kMuted, "km/h");
+
+			char target[32]{};
+			std::snprintf(target, sizeof(target), "TARGET %d", snapshot.m_TargetSpeedKph);
+			drawList->AddText(font, 12.0f * scale, {projection.m_PanelMin.x + 88.0f * scale, projection.m_PanelMin.y + 21.0f * scale}, kMuted, target);
+			drawList->AddText(font, 13.0f * scale, {projection.m_PanelMin.x + 88.0f * scale, projection.m_PanelMin.y + 42.0f * scale}, kText, PhaseLabel(snapshot));
+
+			const auto owner = snapshot.m_Owner == Owner::Npc ? "NPC AUTO" : "AUTO";
+			const auto ownerSize = ImGui::CalcTextSize(owner);
+			drawList->AddText({projection.m_PanelMax.x - ownerSize.x - 18.0f * scale, projection.m_PanelMin.y + 22.0f * scale}, kBlue, owner);
+			drawList->AddLine({projection.m_PanelMin.x + 16.0f * scale, projection.m_PanelMin.y + 70.0f * scale}, {projection.m_PanelMax.x - 16.0f * scale, projection.m_PanelMin.y + 70.0f * scale}, IM_COL32(112, 139, 158, 80), 1.0f);
+
+			if (snapshot.m_Maneuver == HudManeuver::None)
+				return;
+			const auto changingRight = snapshot.m_Maneuver == HudManeuver::LaneChangeRight;
+			const auto label = changingRight ? "CHANGING LANE RIGHT" : "CHANGING LANE LEFT";
+			const auto labelSize = ImGui::CalcTextSize(label);
+			const auto labelY = projection.m_PanelMin.y + 78.0f * scale;
+			drawList->AddText({projection.m_CenterX - labelSize.x * 0.5f, labelY}, kBlue, label);
+			const auto pulse = static_cast<int>(ImGui::GetTime() * 4.0) % 3;
+			for (int index = 0; index < 3; ++index)
+			{
+				const auto x = projection.m_CenterX + (index - 1) * 12.0f * scale;
+				const auto alpha = index == pulse ? 1.0f : 0.38f;
+				const auto direction = changingRight ? 1.0f : -1.0f;
+				const ImVec2 tip{x + direction * 5.0f * scale, labelY + 23.0f * scale};
+				drawList->AddLine({x - direction * 3.0f * scale, tip.y - 5.0f * scale}, tip, WithAlpha(kBlue, alpha), 2.0f * scale);
+				drawList->AddLine(tip, {x - direction * 3.0f * scale, tip.y + 5.0f * scale}, WithAlpha(kBlue, alpha), 2.0f * scale);
+			}
+		}
+	}
+
+	void AutoDriveHUD::Draw()
+	{
+		static std::unordered_map<std::uint32_t, RenderEntity> renderEntities;
+		static std::chrono::steady_clock::time_point lastSnapshotTime{};
+
+		const auto snapshot = AutoDriveHudTelemetry::GetSnapshot();
+		const auto now = std::chrono::steady_clock::now();
+		if (!snapshot || !AutoDriveHudTelemetry::IsEnabled() || !snapshot->m_Visible || snapshot->m_Suppressed
+		    || snapshot->m_CapturedAt == std::chrono::steady_clock::time_point{} || now - snapshot->m_CapturedAt > 500ms)
+		{
+			renderEntities.clear();
+			lastSnapshotTime = {};
+			return;
+		}
+
+		if (snapshot->m_CapturedAt != lastSnapshotTime)
+		{
+			for (const auto& entity : snapshot->m_Entities)
+				renderEntities[entity.m_TrackId] = {entity, now};
+			lastSnapshotTime = snapshot->m_CapturedAt;
+		}
+		for (auto iterator = renderEntities.begin(); iterator != renderEntities.end();)
+		{
+			if (now - iterator->second.m_LastSeen > 150ms)
+				iterator = renderEntities.erase(iterator);
+			else
+				++iterator;
+		}
+
+		const auto viewport = ImGui::GetMainViewport();
+		const auto workWidth = viewport->WorkSize.x;
+		const auto workHeight = viewport->WorkSize.y;
+		const auto scale = std::clamp(std::min(workWidth / 1920.0f, workHeight / 1080.0f), 0.70f, 1.25f);
+		const auto width = std::clamp(420.0f * scale, 280.0f, 480.0f);
+		const auto maximumHeight = std::max(240.0f, std::min(680.0f, workHeight - 40.0f));
+		const auto height = std::clamp(600.0f * scale, std::min(360.0f, maximumHeight), maximumHeight);
+		const ImVec2 position{
+		    viewport->WorkPos.x + workWidth - width - 20.0f * scale,
+		    viewport->WorkPos.y + (workHeight - height) * 0.5f};
+
+		ImGui::SetNextWindowPos(position, ImGuiCond_Always);
+		ImGui::SetNextWindowSize({width, height}, ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(0.0f);
+		const auto flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove
+		    | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar
+		    | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoInputs
+		    | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoBringToFrontOnFocus;
+		if (!ImGui::Begin("##autodrive-fsd-hud", nullptr, flags))
+		{
+			ImGui::End();
+			return;
+		}
+
+		auto drawList = ImGui::GetWindowDrawList();
+		const ImVec2 panelMin = ImGui::GetWindowPos();
+		const ImVec2 panelMax = panelMin + ImGui::GetWindowSize();
+		drawList->AddRectFilled(panelMin, panelMax, kPanel, 16.0f * scale);
+		drawList->AddRect(panelMin, panelMax, kPanelBorder, 16.0f * scale, ImDrawFlags_None, 1.0f);
+		drawList->PushClipRect(panelMin, panelMax, true);
+
+		const Projection projection{
+		    panelMin,
+		    panelMax,
+		    (panelMin.x + panelMax.x) * 0.5f,
+		    panelMin.y + height * 0.78f,
+		    panelMin.y + 108.0f * scale,
+		    width};
+
+		for (const auto& boundary : snapshot->m_LaneBoundaries)
+			DrawPolyline(drawList, projection, boundary, kLane, std::max(1.0f, 1.25f * scale));
+		DrawRoute(drawList, projection, *snapshot, scale);
+
+		std::vector<std::pair<float, RenderEntity*>> sorted;
+		sorted.reserve(renderEntities.size());
+		for (auto& [id, entity] : renderEntities)
+			sorted.emplace_back(entity.m_Data.m_Position.m_Y, &entity);
+		std::sort(sorted.begin(), sorted.end(), [](const auto& left, const auto& right) {
+			return left.first > right.first;
+		});
+		for (const auto& [depth, renderEntity] : sorted)
+		{
+			auto entity = renderEntity->m_Data;
+			const auto extrapolation = std::clamp(std::chrono::duration<float>(now - snapshot->m_CapturedAt).count(), 0.0f, 0.1f);
+			entity.m_Position.m_X += entity.m_Velocity.m_X * extrapolation;
+			entity.m_Position.m_Y += entity.m_Velocity.m_Y * extrapolation;
+			const auto fade = 1.0f - std::clamp(std::chrono::duration<float>(now - renderEntity->m_LastSeen - 50ms).count() / 0.1f, 0.0f, 1.0f);
+			DrawEntity(drawList, projection, entity, fade);
+		}
+
+		DrawEgoVehicle(drawList, projection, scale);
+		DrawHeader(drawList, projection, *snapshot, scale);
+		drawList->PopClipRect();
+		ImGui::End();
+	}
+}

--- a/src/game/frontend/AutoDriveHUD.hpp
+++ b/src/game/frontend/AutoDriveHUD.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace YimMenu
+{
+	class AutoDriveHUD
+	{
+	public:
+		static void Draw();
+	};
+}

--- a/src/game/frontend/GUI.cpp
+++ b/src/game/frontend/GUI.cpp
@@ -3,6 +3,7 @@
 #include "Menu.hpp"
 #include "ESP.hpp"
 #include "Overlay.hpp"
+#include "AutoDriveHUD.hpp"
 #include "core/backend/ScriptMgr.hpp"
 #include "core/renderer/Renderer.hpp"
 #include "core/frontend/Notifications.hpp"
@@ -39,6 +40,11 @@ namespace YimMenu
 			    ChatDisplay::Draw();
 		    },
 		    -5);
+		Renderer::AddRendererCallBack(
+		    [&] {
+			    AutoDriveHUD::Draw();
+		    },
+		    -7);
 		Renderer::AddRendererCallBack(
 		    [&] {
 			    Overlay::Draw();

--- a/src/game/frontend/submenus/Vehicle.cpp
+++ b/src/game/frontend/submenus/Vehicle.cpp
@@ -1,4 +1,6 @@
 #include "Vehicle.hpp"
+#include "core/commands/BoolCommand.hpp"
+#include "core/commands/Commands.hpp"
 #include "game/frontend/items/Items.hpp"
 #include "game/frontend/submenus/Vehicle/SpawnVehicle.hpp"
 #include "Vehicle/VehicleEditor.hpp"
@@ -7,7 +9,7 @@
 namespace YimMenu::Submenus
 {
 	Vehicle::Vehicle() :
-		#define ICON_FA_CAR "\xef\x86\xb9"
+#define ICON_FA_CAR "\xef\x86\xb9"
 	    Submenu::Submenu("Vehicle", ICON_FA_CAR)
 	{
 		auto main = std::make_shared<Category>("Main");
@@ -21,6 +23,16 @@ namespace YimMenu::Submenus
 		globals->AddItem(std::make_shared<BoolCommandItem>("hornboost"_J));
 		globals->AddItem(std::make_shared<BoolCommandItem>("modifyboostbehavior"_J));
 		globals->AddItem(std::make_shared<ConditionalItem>("modifyboostbehavior"_J, std::make_shared<ListCommandItem>("boostbehavior"_J)));
+		globals->AddItem(std::make_shared<BoolCommandItem>("autodrive"_J));
+		globals->AddItem(std::make_shared<BoolCommandItem>("npcautodrive"_J));
+		auto isAutoDriveEnabled = [] {
+			const auto playerAutoDrive = Commands::GetCommand<BoolCommand>("autodrive"_J);
+			const auto npcAutoDrive = Commands::GetCommand<BoolCommand>("npcautodrive"_J);
+			return (playerAutoDrive && playerAutoDrive->GetState())
+			    || (npcAutoDrive && npcAutoDrive->GetState());
+		};
+		globals->AddItem(std::make_shared<ConditionalItem>(isAutoDriveEnabled, std::make_shared<IntCommandItem>("autodrivespeed"_J)));
+		globals->AddItem(std::make_shared<ConditionalItem>(isAutoDriveEnabled, std::make_shared<ListCommandItem>("autodrivestyle"_J)));
 
 		tools->AddItem(std::make_shared<CommandItem>("enterlastvehicle"_J));
 		tools->AddItem(std::make_shared<CommandItem>("repairvehicle"_J));

--- a/src/game/frontend/submenus/Vehicle.cpp
+++ b/src/game/frontend/submenus/Vehicle.cpp
@@ -25,6 +25,7 @@ namespace YimMenu::Submenus
 		globals->AddItem(std::make_shared<ConditionalItem>("modifyboostbehavior"_J, std::make_shared<ListCommandItem>("boostbehavior"_J)));
 		globals->AddItem(std::make_shared<BoolCommandItem>("autodrive"_J));
 		globals->AddItem(std::make_shared<BoolCommandItem>("npcautodrive"_J));
+		globals->AddItem(std::make_shared<BoolCommandItem>("autodrivehud"_J));
 		auto isAutoDriveEnabled = [] {
 			const auto playerAutoDrive = Commands::GetCommand<BoolCommand>("autodrive"_J);
 			const auto npcAutoDrive = Commands::GetCommand<BoolCommand>("npcautodrive"_J);

--- a/src/game/pointers/Pointers.cpp
+++ b/src/game/pointers/Pointers.cpp
@@ -107,9 +107,10 @@ namespace YimMenu
 			ScriptGlobals = ptr.Add(7).Add(3).Rip().As<std::int64_t**>();
 		});
 
-		constexpr auto triggerWeaponDamageEventPtrn = Pattern<"E8 ? ? ? ? 66 90 FF C5">("TriggerWeaponDamageEvent");
-		scanner.Add(triggerWeaponDamageEventPtrn, [this](PointerCalculator ptr) {
-			TriggerWeaponDamageEvent = ptr.Add(1).Rip().As<Functions::TriggerWeaponDamageEvent>();
+		constexpr auto sendNetworkDamagePtrn = Pattern<"0F B6 41 28 04 FE 3C 03 0F 87 ? ? ? ? 48 83 BF D0 00 00 00 00">("SendNetworkDamage");
+		scanner.Add(sendNetworkDamagePtrn, [this](PointerCalculator ptr) {
+			TriggerWeaponDamageEvent = ptr.Sub(0x51).As<Functions::TriggerWeaponDamageEvent>();
+
 		});
 
 		constexpr auto scriptProgramsPtrn = Pattern<"48 C7 84 C8 D8 00 00 00 00 00 00 00">("ScriptPrograms");
@@ -199,10 +200,11 @@ namespace YimMenu
 			NetEventMgr = ptr.Add(3).Rip().As<rage::netEventMgr**>();
 		});
 
-		constexpr auto sendEventAckPtrn = Pattern<"E8 ? ? ? ? 84 C0 75 ? 44 89 F5">("SendEventAck");
+		constexpr auto sendEventAckPtrn = Pattern<"84 C0 75 ? 44 89 F5 4D 8D B4 24 08 C4 02 00">("SendEventAck");
 		scanner.Add(sendEventAckPtrn, [this](PointerCalculator ptr) {
-			EventAck = ptr.Add(1).Rip().As<Functions::EventAck>();
-			SendEventAck = ptr.Add(0x1A).Add(1).Rip().As<Functions::SendEventAck>();
+			EventAck = ptr.Sub(4).Rip().As<Functions::EventAck>();
+			SendEventAck = ptr.Add(0x15).Add(1).Rip().As<Functions::SendEventAck>();
+
 		});
 
 		constexpr auto queueDependencyPtrn = Pattern<"0F 29 46 50 48 8D 05">("QueueDependency&SigScanMemory");
@@ -216,9 +218,10 @@ namespace YimMenu
 			ScriptVM = ptr.Sub(0x24).As<Functions::ScriptVM>();
 		});
 
-		constexpr auto prepareMetricForSendingPtrn = Pattern<"41 56 56 57 55 53 48 83 EC ? 4C 89 CB 4C 89 C6">("PrepareMetricForSending");
+		constexpr auto prepareMetricForSendingPtrn = Pattern<"48 89 F1 FF 50 20 48 8D 15 ? ? ? ? 48 89 F9 49 89 C0">("PrepareMetricForSending");
 		scanner.Add(prepareMetricForSendingPtrn, [this](PointerCalculator ptr) {
-			PrepareMetricForSending = ptr.As<PVOID>();
+			PrepareMetricForSending = ptr.Sub(0x4B).As<PVOID>();
+
 		});
 
 		constexpr auto beDataPtrn = Pattern<"48 C7 05 ? ? ? ? 00 00 00 00 E8 ? ? ? ? 48 89 C1 E8 ? ? ? ? E8 ? ? ? ? BD 0A 00 00 00">("BEData");
@@ -228,9 +231,11 @@ namespace YimMenu
 			IsBEBanned = ptr.Add(3).Rip().Add(8).Add(4).Add(8).Add(4).As<bool*>();
 		});
 
-		constexpr auto battlEyeStatusUpdatePatchPtrn = Pattern<"C6 05 ? ? ? ? 00 84 C0 0F 84 ? ? ? ? E9">("BattlEyeStatusUpdatePatch");
+		constexpr auto battlEyeStatusUpdatePatchPtrn = Pattern<"80 B9 92 0A 00 00 01 48 81 D1 90 0A 00 00">("BattlEyeStatusUpdatePatch");
 		scanner.Add(battlEyeStatusUpdatePatchPtrn, [this](PointerCalculator ptr) {
-			BattlEyeStatusUpdatePatch = BytePatches::Add(ptr.Add(11).Rip().Add(1).Rip().As<void*>(), std::to_array<std::uint8_t>({0xC3}));
+			BattlEyeStatusUpdatePatch = BytePatches::Add(ptr.Add(0x10C).As<void*>(),
+				std::to_array<std::uint8_t>({0x31, 0xC0, 0xC3})); // xor eax, eax; ret
+
 		});
 
 		constexpr auto writeNetArrayDataPtrn = Pattern<"0F 84 06 03 00 00 0F B6 83">("WriteNetArrayData");
@@ -295,9 +300,10 @@ namespace YimMenu
 			NetworkSession = ptr.Add(0x17).Add(3).Rip().As<CNetworkSession**>();
 		});
 
-		constexpr auto joinSessionByInfoPtrn = Pattern<"E8 ? ? ? ? 0F 10 87 ? ? ? ? 0F 11 86 ? ? ? ? 88 86 ? ? ? ? 84 C0">("JoinSessionByInfo");
+		constexpr auto joinSessionByInfoPtrn = Pattern<"41 57 41 56 56 57 55 53 48 83 EC 68 44 89 CF 45 89 C7 48 89 D5 48 89 CE B1 01">("JoinSessionByInfo");
 		scanner.Add(joinSessionByInfoPtrn, [this](PointerCalculator ptr) {
-			JoinSessionByInfo = ptr.Add(1).Rip().As<Functions::JoinSessionByInfo>();
+			JoinSessionByInfo = ptr.As<Functions::JoinSessionByInfo>();
+
 		});
 
 		constexpr auto getSessionByGamerHandle = Pattern<"48 C7 84 24 80 00 00 00 10 00 00 08">("GetSessionByGamerHandle");
@@ -361,7 +367,8 @@ namespace YimMenu
 			SetJoinRequestPoolTypePatch = BytePatches::Add(ptr.Sub(5).As<std::uint8_t*>(), std::to_array<std::uint8_t>({0xB8, 0x00, 0x00, 0x00, 0x00}));
 		});
 
-		constexpr auto handleJoinRequestIgnorePoolPatchPtrn = Pattern<"41 83 FF ? 74 ? 41 83 FF ? 0F 84 ? ? ? ? 45 85 FF 75">("HandleJoinRequestIgnorePoolPatch");
+		constexpr auto handleJoinRequestIgnorePoolPatchPtrn = Pattern<"41 83 FF 05 74 ? 41 83 FF 01">("HandleJoinRequestIgnorePoolPatch");
+
 		scanner.Add(handleJoinRequestIgnorePoolPatchPtrn, [this](PointerCalculator ptr) {
 			HandleJoinRequestIgnorePoolPatch = BytePatches::Add(ptr.As<void*>(), std::to_array<std::uint8_t>({0x39, 0xC9, 0x90, 0x90}));
 		});


### PR DESCRIPTION
Auto Drive was one of my favorite v1 features, so this restores it in V2. It follows the map waypoint using roads, or wanders when none is set.

Tested in-game and working. It has been tested over a distance of 2,000 kilometers, and the logic is functioning normally.

Video preview:

https://github.com/user-attachments/assets/27b8d086-64ba-45d8-92e0-dbd594cab63f

Image preview:

<img width="2541" height="1518" alt="image" src="https://github.com/user-attachments/assets/8e3807b2-2f3f-403c-9fe9-9ee76aeb2657" />

