### PR TITLE
汉化科兹中心豪劫功能 / Localize Kortz Center Heist to Chinese

### DIFF
--- a/src/game/features/recovery/Heist/KortzCenterHeist.cpp
+++ b/src/game/features/recovery/Heist/KortzCenterHeist.cpp
@@ -13,67 +13,67 @@ namespace YimMenu::Features
 	{
 		// --- Primary Target ---
 		static std::vector<std::pair<int, const char*>> kortzCenterTargets = {
-		    {0, "La Dernière Débauche"},
-		    {1, "Hare Oneself Think"},
-		    {2, "The Downfall Rome"},
-		    {3, "Brother Brother"},
-		    {4, "A Cast Characters"},
-		    {5, "Gone To Seed"},
-		    {6, "True Love"},
-		    {7, "Breathless"},
-		    {8, "Consumato"},
-		    {9, "I Hear Voices"},
-		    {10, "Winter, Nowhere in Particular"},
-		    {11, "The Girl With Pearl Necklace"},
-		    {12, "Chat on Fruit"},
-		    {13, "Pumpkin"},
-		    {14, "Twindifference"},
-		    {15, "Stacks Study V"},
-		    {16, "I, Fruit"},
-		    {17, "To Beat About Bush"},
-		    {18, "In Excess of Success"},
-		    {19, "Juiced"},
-		    {20, "A Winding Road Home"},
-		    {21, "Teckels"},
-		    {22, "Trust"},
-		    {23, "Until Death"},
-		    {24, "What Melons?"},
-		    {25, "The Outcome Endeavour"},
-		    {26, "Mi O Melee"}
+		    {0, "最后的放纵"},
+		    {1, "兔子独自思考"},
+		    {2, "罗马的陨落"},
+		    {3, "兄弟兄弟"},
+		    {4, "一众角色"},
+		    {5, "走向衰败"},
+		    {6, "真爱"},
+		    {7, "窒息"},
+		    {8, "圆满"},
+		    {9, "我听到声音"},
+		    {10, "冬天，不知何处"},
+		    {11, "戴珍珠项链的女孩"},
+		    {12, "水果聊天"},
+		    {13, "南瓜"},
+		    {14, "双重差异"},
+		    {15, "堆叠研究V"},
+		    {16, "我，水果"},
+		    {17, "拐弯抹角"},
+		    {18, "成功过剩"},
+		    {19, "榨汁"},
+		    {20, "回家的曲折之路"},
+		    {21, "腊肠犬"},
+		    {22, "信任"},
+		    {23, "至死不渝"},
+		    {24, "什么瓜？"},
+		    {25, "奋斗的成果"},
+		    {26, "我的近战"}
 		};
-		static ListCommand _KortzCenterPrimaryTarget{"kortzcenterheistprimarytarget", "Primary Target", "Primary target", kortzCenterTargets, 0};
+		static ListCommand _KortzCenterPrimaryTarget{"kortzcenterheistprimarytarget", "主要目标", "主要目标", kortzCenterTargets, 0};
 
 		// --- General Purchases (MPX_K26_GENERAL_BS bits 5-8) ---
-		static BoolCommand _KortzCenterGuardRoutes{"kortzcenterheistguardroutes", "Guard Routes", "Guard routes purchased", true};
-		static BoolCommand _KortzCenterGlassCutter{"kortzcenterheistglasscutter", "Glass Cutter", "Glass cutter purchased", true};
-		static BoolCommand _KortzCenterPowerDrills{"kortzcenterheistpowerdrills", "Power Drills", "Power drills purchased", true};
-		static BoolCommand _KortzCenterEMPCharges{"kortzcenterheistempcharges", "EMP Charges", "EMP charges purchased", true};
+		static BoolCommand _KortzCenterGuardRoutes{"kortzcenterheistguardroutes", "守卫路线", "守卫路线已购买", true};
+		static BoolCommand _KortzCenterGlassCutter{"kortzcenterheistglasscutter", "玻璃切割器", "玻璃切割器已购买", true};
+		static BoolCommand _KortzCenterPowerDrills{"kortzcenterheistpowerdrills", "电钻", "电钻已购买", true};
+		static BoolCommand _KortzCenterEMPCharges{"kortzcenterheistempcharges", "EMP电磁脉冲", "EMP电磁脉冲已购买", true};
 
 		// --- Prep Work Items ---
-		static BoolCommand _KortzCenterScopeOut{"kortzcenterheistscopeout", "Scope Out", "Scope out Kortz Center", true};
-		static BoolCommand _KortzCenterAlphaMail{"kortzcenterheistalphamail", "Alpha Mail Disguise", "Alpha mail disguise", true};
-		static BoolCommand _KortzCenterHazmat{"kortzcenterheisthazmat", "Hazmat Suit", "Hazmat suit", true};
-		static BoolCommand _KortzCenterStaffKeycard{"kortzcenterheiststaffkeycard", "Staff Key Card", "Staff key card", true};
-		static BoolCommand _KortzCenterTacticalEquip{"kortzcenterheisttacticalequip", "Tactical Equipment", "Tactical equipment", true};
-		static BoolCommand _KortzCenterHackingDevice{"kortzcenterheisthackingdevice", "Hacking Device", "Hacking device", true};
-		static BoolCommand _KortzCenterAccessCode{"kortzcenterheistaccesscode", "Access Code", "Access code", true};
-		static BoolCommand _KortzCenterUnmarkedWeapons{"kortzcenterheistunmarkedweapons", "Unmarked Weapons", "Unmarked weapons", true};
-		static BoolCommand _KortzCenterCaracara{"kortzcenterheistcaracara", "Armored Caracara", "Armored Caracara", true};
-		static BoolCommand _KortzCenterAnnihilator{"kortzcenterheistannihilator", "Annihilator Stealth", "Annihilator stealth", true};
-		static BoolCommand _KortzCenterManchez{"kortzcenterheistmanchez", "Manchez", "Manchez", true};
-		static BoolCommand _KortzCenterPrepEMP{"kortzcenterheistprepemp", "EMP Charges (Prep)", "EMP charges prep", true};
-		static BoolCommand _KortzCenterGuardShipments{"kortzcenterheistguardshipments", "Guard Shipments", "Guard shipments", true};
-		static BoolCommand _KortzCenterGuardRoutesPrep{"kortzcenterheistguardroutesprep", "Guard Routes (Prep)", "Guard routes prep", true};
-		static BoolCommand _KortzCenterGlassCutterPrep{"kortzcenterheistglasscutterprep", "Glass Cutter (Prep)", "Glass cutter prep", true};
-		static BoolCommand _KortzCenterPowerDrillsPrep{"kortzcenterheistpowerdrillsprep", "Power Drills (Prep)", "Power drills prep", true};
-		static BoolCommand _KortzCenterEMPChargesPrep{"kortzcenterheistempchargesprep", "EMP Charges (Prep)", "EMP charges prep", true};
-		static BoolCommand _KortzCenterCaracaraPrep{"kortzcenterheistcaracaraprep", "Caracara (Prep)", "Armored Caracara prep", true};
-		static BoolCommand _KortzCenterAnnihilatorPrep{"kortzcenterheistannihilatorprep", "Annihilator (Prep)", "Annihilator stealth prep", true};
-		static BoolCommand _KortzCenterManchezPrep{"kortzcenterheistmanchezprep", "Manchez (Prep)", "Manchez prep", true};
+		static BoolCommand _KortzCenterScopeOut{"kortzcenterheistscopeout", "侦查科兹中心", "侦查科兹中心", true};
+		static BoolCommand _KortzCenterAlphaMail{"kortzcenterheistalphamail", "阿尔法快递伪装", "阿尔法快递伪装", true};
+		static BoolCommand _KortzCenterHazmat{"kortzcenterheisthazmat", "防护服", "防护服", true};
+		static BoolCommand _KortzCenterStaffKeycard{"kortzcenterheiststaffkeycard", "员工钥匙卡", "员工钥匙卡", true};
+		static BoolCommand _KortzCenterTacticalEquip{"kortzcenterheisttacticalequip", "战术装备", "战术装备", true};
+		static BoolCommand _KortzCenterHackingDevice{"kortzcenterheisthackingdevice", "黑客设备", "黑客设备", true};
+		static BoolCommand _KortzCenterAccessCode{"kortzcenterheistaccesscode", "访问代码", "访问代码", true};
+		static BoolCommand _KortzCenterUnmarkedWeapons{"kortzcenterheistunmarkedweapons", "无标记武器", "无标记武器", true};
+		static BoolCommand _KortzCenterCaracara{"kortzcenterheistcaracara", "装甲卡拉卡拉", "装甲卡拉卡拉", true};
+		static BoolCommand _KortzCenterAnnihilator{"kortzcenterheistannihilator", "歼灭者隐形直升机", "歼灭者隐形直升机", true};
+		static BoolCommand _KortzCenterManchez{"kortzcenterheistmanchez", "曼切斯摩托", "曼切斯摩托", true};
+		static BoolCommand _KortzCenterPrepEMP{"kortzcenterheistprepemp", "EMP电磁脉冲(前置)", "EMP电磁脉冲前置任务", true};
+		static BoolCommand _KortzCenterGuardShipments{"kortzcenterheistguardshipments", "守卫货物", "守卫货物", true};
+		static BoolCommand _KortzCenterGuardRoutesPrep{"kortzcenterheistguardroutesprep", "守卫路线(前置)", "守卫路线前置任务", true};
+		static BoolCommand _KortzCenterGlassCutterPrep{"kortzcenterheistglasscutterprep", "玻璃切割器(前置)", "玻璃切割器前置任务", true};
+		static BoolCommand _KortzCenterPowerDrillsPrep{"kortzcenterheistpowerdrillsprep", "电钻(前置)", "电钻前置任务", true};
+		static BoolCommand _KortzCenterEMPChargesPrep{"kortzcenterheistempchargesprep", "EMP电磁脉冲(前置)", "EMP电磁脉冲前置任务", true};
+		static BoolCommand _KortzCenterCaracaraPrep{"kortzcenterheistcaracaraprep", "卡拉卡拉(前置)", "装甲卡拉卡拉前置任务", true};
+		static BoolCommand _KortzCenterAnnihilatorPrep{"kortzcenterheistannihilatorprep", "歼灭者(前置)", "歼灭者隐形直升机前置任务", true};
+		static BoolCommand _KortzCenterManchezPrep{"kortzcenterheistmanchezprep", "曼切斯(前置)", "曼切斯摩托前置任务", true};
 
 		// --- Scoping ---
-		static BoolCommand _KortzCenterScopeSecondary{"kortzcenterheistscopesecondary", "Secondary Targets", "Scope secondary targets", true};
-		static BoolCommand _KortzCenterScopePOI{"kortzcenterheistscopepoi", "Points of Interest", "Scope points of interest", true};
+		static BoolCommand _KortzCenterScopeSecondary{"kortzcenterheistscopesecondary", "次要目标", "侦查次要目标", true};
+		static BoolCommand _KortzCenterScopePOI{"kortzcenterheistscopepoi", "兴趣点", "侦查兴趣点", true};
 
 		// --- In-Heist Shortcuts ---
 		class SkipFingerprint : public Command
@@ -206,13 +206,13 @@ namespace YimMenu::Features
 			}
 		};
 
-		static SkipFingerprint _KortzCenterSkipFingerprint{"kortzcenterheistskipfingerprint", "Skip Fingerprint Hack", "Skips fingerprint hacking minigame in computer room"};
-		static SkipSignalNodes _KortzCenterSkipSignalNodes{"kortzcenterheistskipsignalnodes", "Skip Signal Nodes", "Skips signal nodes hacking at vault keypad"};
-		static SkipDataCrack _KortzCenterSkipDataCrack{"kortzcenterheistskipdatacrack", "Skip Data Crack", "Skips data crack minigame"};
-		static CutGlass _KortzCenterCutGlass{"kortzcenterheistcutglass", "Cut Glass", "Cuts display case glass instantly"};
-		static DisableLaserGrid _KortzCenterDisableLaser{"kortzcenterheistdisablelaser", "Disable Laser Grid", "Disables laser security grid"};
-		static TakePrimaryTarget _KortzCenterTakePrimary{"kortzcenterheisttakeprimary", "Take Primary Target", "Takes primary target painting (stand near it)"};
-		static TakeSecondaryTarget _KortzCenterTakeSecondary{"kortzcenterheisttakesecondary", "Take Secondary Target", "Takes secondary loot (stand near it)"};
-		static Setup _KortzCenterSetup{"kortzcenterheistsetup", "Setup", "Sets up Kortz Center heist"};
+		static SkipFingerprint _KortzCenterSkipFingerprint{"kortzcenterheistskipfingerprint", "跳过指纹识别", "跳过电脑室指纹识别小游戏"};
+		static SkipSignalNodes _KortzCenterSkipSignalNodes{"kortzcenterheistskipsignalnodes", "跳过信号节点", "跳过保险库键盘信号节点黑客破解"};
+		static SkipDataCrack _KortzCenterSkipDataCrack{"kortzcenterheistskipdatacrack", "跳过数据破解", "跳过数据破解小游戏"};
+		static CutGlass _KortzCenterCutGlass{"kortzcenterheistcutglass", "切割玻璃", "立即切割展柜玻璃"};
+		static DisableLaserGrid _KortzCenterDisableLaser{"kortzcenterheistdisablelaser", "禁用激光网格", "禁用激光安全网格"};
+		static TakePrimaryTarget _KortzCenterTakePrimary{"kortzcenterheisttakeprimary", "获取主要目标", "获取主要目标画作(站在画作附近)"};
+		static TakeSecondaryTarget _KortzCenterTakeSecondary{"kortzcenterheisttakesecondary", "获取次要目标", "获取次要战利品(站在战利品附近)"};
+		static Setup _KortzCenterSetup{"kortzcenterheistsetup", "应用(立即完成前置任务)", "按上述配置跳过科兹中心前置任务"};
 	}
 }

--- a/src/game/frontend/submenus/Recovery/Heist/KortzCenterHeist.cpp
+++ b/src/game/frontend/submenus/Recovery/Heist/KortzCenterHeist.cpp
@@ -4,14 +4,14 @@ namespace YimMenu::Submenus
 {
 	std::shared_ptr<TabItem> RenderKortzCenterHeistMenu()
 	{
-		auto tab   = std::make_shared<TabItem>("Kortz Center Heist");
+		auto tab   = std::make_shared<TabItem>("科兹中心抢劫");
 
-		auto target    = std::make_shared<Group>("Primary Target", 1);
-		auto general   = std::make_shared<Group>("General", 2);
+		auto target    = std::make_shared<Group>("主要目标", 1);
+		auto general   = std::make_shared<Group>("常规", 2);
 
-		auto vehicles  = std::make_shared<CollapsingHeaderItem>("Vehicles");
-		auto equipment = std::make_shared<CollapsingHeaderItem>("Equipment");
-		auto intel     = std::make_shared<CollapsingHeaderItem>("Intel");
+		auto vehicles  = std::make_shared<CollapsingHeaderItem>("载具");
+		auto equipment = std::make_shared<CollapsingHeaderItem>("装备");
+		auto intel     = std::make_shared<CollapsingHeaderItem>("情报");
 
 		auto action    = std::make_shared<Group>("", 1);
 
@@ -47,7 +47,7 @@ namespace YimMenu::Submenus
 		intel->AddItem(std::make_shared<BoolCommandItem>("kortzcenterheistscopesecondary"_J));
 		intel->AddItem(std::make_shared<BoolCommandItem>("kortzcenterheistscopepoi"_J));
 
-		auto inHeist = std::make_shared<Group>("In-Heist", 2);
+		auto inHeist = std::make_shared<Group>("抢劫内辅助", 2);
 
 		inHeist->AddItem(std::make_shared<CommandItem>("kortzcenterheistskipfingerprint"_J));
 		inHeist->AddItem(std::make_shared<CommandItem>("kortzcenterheistskipsignalnodes"_J));


### PR DESCRIPTION
# 汉化科兹中心豪劫功能 / Localize Kortz Center Heist to Chinese

## 概述 / Summary

本 PR 将科兹中心豪劫（Kortz Center Heist）的所有界面文本汉化为简体中文，使中文用户能够更好地使用该功能。

This PR localizes all Kortz Center Heist interface text to Simplified Chinese, making the feature more accessible to Chinese users.

## 修改内容 / Changes

### 修改的文件 / Modified Files

1. `src/game/features/recovery/Heist/KortzCenterHeist.cpp`
   - 汉化了所有 27 个主要目标画作名称
   - 汉化了所有装备、载具、抢劫内辅助功能的命令和描述

2. `src/game/frontend/submenus/Recovery/Heist/KortzCenterHeist.cpp`
   - 汉化了界面标题和分组名称
   - 保持了与其他已汉化豪劫（佩里科岛、赌场）的翻译风格一致

## 翻译原则 / Translation Principles

- ✅ 仅修改字符串常量（string literals）
- ✅ 参考了已有的佩里科岛豪劫和赌场豪劫的中文翻译风格
- ✅ 保持了代码结构和逻辑完全不变
- ✅ 所有翻译均由人工审核确保准确性

## 测试 / Testing

- ✅ 代码已通过编译
- ✅ 界面显示正常，所有文本正确显示中文
- ✅ 功能测试通过，所有命令正常工作

## 声明 / Declaration

- ✅ 本 PR 仅包含文本翻译，不包含任何代码逻辑修改
- ✅ 所有翻译由人工完成并审核
- ✅ 遵循项目的贡献指南

感谢审核！🙏
Thank you for reviewing!
