### PR TITLE
feat: harden network parsing and add runtime diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build and run unit tests
         run: |
-          cmake --build ./build --config RelWithDebInfo --target dat_bit_buffer_tests --
+          cmake --build ./build --config RelWithDebInfo --target dat_bit_buffer_tests protection_telemetry_tests --
           ctest --test-dir ./build --build-config RelWithDebInfo --output-on-failure
 
       - name: Check if DLL got built

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Build 64bit RelWithDebInfo DLL
         run: cmake --build ./build --config RelWithDebInfo --target YimMenuV2 --
 
+      - name: Build and run unit tests
+        run: |
+          cmake --build ./build --config RelWithDebInfo --target dat_bit_buffer_tests --
+          ctest --test-dir ./build --build-config RelWithDebInfo --output-on-failure
+
       - name: Check if DLL got built
         run: if (-Not (Test-Path -path "build/YimMenuV2.dll")) {throw 1}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.20.x)
 include(cmake/cross-compile.cmake)
 
 project(YimMenuV2 VERSION 0.0.1 DESCRIPTION "A new base using new C++ features optimised for speed and ease of use")
+include(CTest)
 
 # libs
 include(cmake/async-logger.cmake)
@@ -61,3 +62,10 @@ target_compile_options(${PROJECT_NAME} PRIVATE
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-date-time>
     $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-date-time>
 )
+
+if(BUILD_TESTING)
+    add_executable(dat_bit_buffer_tests tests/datBitBufferTests.cpp)
+    target_compile_features(dat_bit_buffer_tests PRIVATE cxx_std_23)
+    target_include_directories(dat_bit_buffer_tests PRIVATE "${SRC_DIR}")
+    add_test(NAME dat_bit_buffer_tests COMMAND dat_bit_buffer_tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ include(cmake/luajit.cmake)
 # source
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/src")
 file(GLOB_RECURSE SRC_FILES
+    CONFIGURE_DEPENDS
     "${SRC_DIR}/**.hpp"
     "${SRC_DIR}/**.cpp"    
 )
@@ -68,4 +69,12 @@ if(BUILD_TESTING)
     target_compile_features(dat_bit_buffer_tests PRIVATE cxx_std_23)
     target_include_directories(dat_bit_buffer_tests PRIVATE "${SRC_DIR}")
     add_test(NAME dat_bit_buffer_tests COMMAND dat_bit_buffer_tests)
+
+    add_executable(protection_telemetry_tests
+        tests/protectionTelemetryTests.cpp
+        src/game/backend/ProtectionTelemetry.cpp
+    )
+    target_compile_features(protection_telemetry_tests PRIVATE cxx_std_23)
+    target_include_directories(protection_telemetry_tests PRIVATE "${SRC_DIR}")
+    add_test(NAME protection_telemetry_tests COMMAND protection_telemetry_tests)
 endif()

--- a/src/core/backend/PatternCache.cpp
+++ b/src/core/backend/PatternCache.cpp
@@ -4,6 +4,28 @@
 
 namespace YimMenu
 {
+	namespace
+	{
+		constexpr std::uint32_t CacheMagic = 0x32434D59; // YMC2
+		constexpr std::uint32_t CacheVersion = 1;
+		constexpr std::uint32_t MaxCacheEntries = 100'000;
+
+		struct CacheHeader
+		{
+			std::uint32_t m_Magic;
+			std::uint32_t m_Version;
+			std::uint32_t m_EntryCount;
+			std::uint32_t m_Reserved;
+		};
+
+		struct CacheEntry
+		{
+			std::uint64_t m_Hash;
+			std::int32_t m_Offset;
+			std::uint32_t m_Reserved;
+		};
+	}
+
 	std::optional<int> PatternCache::GetCachedOffsetImpl(PatternHash hash)
 	{
 		std::lock_guard lock(m_Mutex);
@@ -22,24 +44,37 @@ namespace YimMenu
 	void PatternCache::InitImpl()
 	{
 		std::lock_guard lock(m_Mutex);
+		m_Data.clear();
 
 		auto file = FileMgr::GetProjectFile("./pattern_cache.bin");
 		if (file.Exists())
 		{
 			std::ifstream stream(file.Path(), std::ios_base::binary);
-			while (!stream.eof())
+			CacheHeader header{};
+			if (stream.read(reinterpret_cast<char*>(&header), sizeof(header))
+				&& header.m_Magic == CacheMagic
+				&& header.m_Version == CacheVersion
+				&& header.m_EntryCount <= MaxCacheEntries)
 			{
-				std::uint64_t hash;
-				int offset;
-
-				stream.read(reinterpret_cast<char*>(&hash), sizeof(hash));
-				stream.read(reinterpret_cast<char*>(&offset), sizeof(offset));
-
-				m_Data.emplace(hash, offset);
+				for (std::uint32_t i = 0; i < header.m_EntryCount; ++i)
+				{
+					CacheEntry entry{};
+					if (!stream.read(reinterpret_cast<char*>(&entry), sizeof(entry)))
+					{
+						LOG(WARNING) << "Pattern cache is truncated; discarding cached offsets";
+						m_Data.clear();
+						break;
+					}
+					m_Data.insert_or_assign(entry.m_Hash, entry.m_Offset);
+				}
+			}
+			else
+			{
+				LOG(WARNING) << "Pattern cache has an unsupported or corrupt header; rebuilding it";
 			}
 		}
 
-		m_Initialized = true;
+		m_Initialized.store(true, std::memory_order_release);
 	}
 
 	void PatternCache::UpdateImpl()
@@ -47,13 +82,44 @@ namespace YimMenu
 		std::lock_guard lock(m_Mutex);
 
 		auto file = FileMgr::GetProjectFile("./pattern_cache.bin");
-		std::ofstream stream(file.Path(), std::ios_base::binary);
-
-		for (auto& [h, offset] : m_Data)
+		auto temporary = file.Path();
+		temporary += ".tmp";
+		std::ofstream stream(temporary, std::ios_base::binary | std::ios_base::trunc);
+		if (!stream)
 		{
-			auto hash = h;
-			stream.write(reinterpret_cast<char*>(&hash), sizeof(hash));
-			stream.write(reinterpret_cast<char*>(&offset), sizeof(offset));
+			LOG(WARNING) << "Failed to open the temporary pattern cache";
+			return;
 		}
+
+		const CacheHeader header{CacheMagic, CacheVersion, static_cast<std::uint32_t>(m_Data.size()), 0};
+		stream.write(reinterpret_cast<const char*>(&header), sizeof(header));
+		for (const auto& [hash, offset] : m_Data)
+		{
+			const CacheEntry entry{hash, offset, 0};
+			stream.write(reinterpret_cast<const char*>(&entry), sizeof(entry));
+		}
+		stream.flush();
+		if (!stream)
+		{
+			LOG(WARNING) << "Failed to write the temporary pattern cache";
+			stream.close();
+			std::error_code ec;
+			std::filesystem::remove(temporary, ec);
+			return;
+		}
+		stream.close();
+
+		if (!MoveFileExW(temporary.c_str(), file.Path().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+		{
+			LOGF(WARNING, "Failed to replace the pattern cache: error {}", GetLastError());
+			std::error_code ec;
+			std::filesystem::remove(temporary, ec);
+		}
+	}
+
+	std::size_t PatternCache::GetEntryCountImpl()
+	{
+		std::lock_guard lock(m_Mutex);
+		return m_Data.size();
 	}
 }

--- a/src/core/backend/PatternCache.hpp
+++ b/src/core/backend/PatternCache.hpp
@@ -5,7 +5,7 @@ namespace YimMenu
 {
 	class PatternCache
 	{
-		bool m_Initialized;
+		std::atomic_bool m_Initialized;
 		std::unordered_map<std::uint64_t, int> m_Data;
 		std::mutex m_Mutex;
 
@@ -37,7 +37,12 @@ namespace YimMenu
 
 		static bool IsInitialized()
 		{
-			return GetInstance().m_Initialized;
+			return GetInstance().m_Initialized.load(std::memory_order_acquire);
+		}
+
+		static std::size_t GetEntryCount()
+		{
+			return GetInstance().GetEntryCountImpl();
 		}
 
 	private:
@@ -49,6 +54,7 @@ namespace YimMenu
 
 		void InitImpl();
 		void UpdateImpl();
+		std::size_t GetEntryCountImpl();
 		std::optional<int> GetCachedOffsetImpl(PatternHash hash);
 		void UpdateCachedOffsetImpl(PatternHash hash, int offset);
 	};

--- a/src/core/commands/HotkeySystem.cpp
+++ b/src/core/commands/HotkeySystem.cpp
@@ -32,20 +32,12 @@ namespace YimMenu
 		m_CommandHotkeys.at("chathelper"_J).m_Chain.push_back(0x54);
 	}
 
-	bool HotkeySystem::ListenAndApply(int& Hotkey, std::vector<int> Blacklist)
+	bool HotkeySystem::ListenAndApply(int& Hotkey, const std::vector<int>& Blacklist)
 	{
-		static auto IsKeyBlacklisted = [Blacklist](int Key) -> bool {
-			for (auto Key_ : Blacklist)
-				if (Key_ == Key)
-					return true;
-
-			return false;
-		};
-
 		// VK_OEM_CLEAR Is about the limit in terms of virtual key codes
 		for (int i = 0; i < VK_OEM_CLEAR; i++)
 		{
-			if ((GetKeyState(i) & 0x8000) && i != 1 && !IsKeyBlacklisted(i))
+			if ((GetKeyState(i) & 0x8000) && i != 1 && std::ranges::find(Blacklist, i) == Blacklist.end())
 			{
 				Hotkey = i;
 
@@ -59,11 +51,11 @@ namespace YimMenu
 	// Will return the keycode if there are no labels
 	std::string HotkeySystem::GetHotkeyLabel(int HotkeyModifier)
 	{
-		char KeyName[32];
-		GetKeyNameTextA(MapVirtualKey(HotkeyModifier, MAPVK_VK_TO_VSC) << 16, KeyName, 32);
+		char KeyName[32]{};
+		GetKeyNameTextA(MapVirtualKey(HotkeyModifier, MAPVK_VK_TO_VSC) << 16, KeyName, static_cast<int>(std::size(KeyName)));
 
-		if (std::string(KeyName).empty())
-			strcpy(KeyName, std::to_string(HotkeyModifier).data());
+		if (KeyName[0] == '\0')
+			return std::to_string(HotkeyModifier);
 
 		return KeyName;
 	}
@@ -112,7 +104,9 @@ namespace YimMenu
 						}
 					}
 
-					if (all_keys_pressed && std::chrono::system_clock::now() - m_LastHotkeyTriggerTime > 100ms)
+					const bool was_pressed = m_WasPressed[hash];
+					m_WasPressed[hash] = all_keys_pressed;
+					if (all_keys_pressed && !was_pressed)
 					{
 						auto command = Commands::GetCommand(hash);
 						if (command)
@@ -127,7 +121,6 @@ namespace YimMenu
 								});
 							}
 						}
-						m_LastHotkeyTriggerTime = std::chrono::system_clock::now();
 					}
 				}
 			}

--- a/src/core/commands/HotkeySystem.hpp
+++ b/src/core/commands/HotkeySystem.hpp
@@ -15,7 +15,7 @@ namespace YimMenu
 	class HotkeySystem :
 	    public IStateSerializer
 	{
-		std::chrono::system_clock::time_point m_LastHotkeyTriggerTime;
+		std::unordered_map<std::uint32_t, bool> m_WasPressed;
 		bool m_BeingModified = false;
 
 	public:
@@ -23,7 +23,7 @@ namespace YimMenu
 
 		std::map<uint32_t, CommandLink> m_CommandHotkeys;
 		void RegisterCommands();
-		bool ListenAndApply(int& Hotkey, std::vector<int> blacklist = {0});
+		bool ListenAndApply(int& Hotkey, const std::vector<int>& blacklist = {0});
 		std::string GetHotkeyLabel(int hotkey_modifiers);
 		void CreateHotkey(std::vector<int>& Hotkey);
 

--- a/src/core/frontend/manager/Category.cpp
+++ b/src/core/frontend/manager/Category.cpp
@@ -8,7 +8,7 @@ namespace YimMenu
 			item->Draw();
 	}
 
-	int Category::GetLength()
+	float Category::GetLength()
 	{
 		if (m_Length.has_value())
 			return m_Length.value();

--- a/src/core/frontend/manager/Category.hpp
+++ b/src/core/frontend/manager/Category.hpp
@@ -32,11 +32,11 @@ namespace YimMenu
 		}
 
 		void Draw();
-		int GetLength();
+		float GetLength();
 
 	private:
 		std::vector<std::shared_ptr<UIItem>> m_Items;
-		std::optional<int> m_Length;
+		std::optional<float> m_Length;
 
 	public:
 		std::string m_Name;

--- a/src/core/logger/ExceptionHandler.cpp
+++ b/src/core/logger/ExceptionHandler.cpp
@@ -3,6 +3,7 @@
 #include "StackTrace.hpp"
 
 #include <hde64.h>
+#include <mutex>
 #include <unordered_set>
 
 
@@ -37,18 +38,27 @@ namespace YimMenu
 			return EXCEPTION_CONTINUE_SEARCH;
 
 		static std::unordered_set<std::size_t> logged_exceptions;
+		static std::mutex logged_exceptions_mutex;
 
 		trace.NewStackTrace(exception_info);
 		const auto trace_hash = HashStackTrace(trace.GetFramePointers());
-		if (const auto it = logged_exceptions.find(trace_hash); it == logged_exceptions.end())
 		{
-			LOG(FATAL) << trace;
-			Logger::FlushQueue();
+			std::lock_guard lock(logged_exceptions_mutex);
+			if (const auto it = logged_exceptions.find(trace_hash); it == logged_exceptions.end())
+			{
+				LOG(FATAL) << trace;
+				Logger::FlushQueue();
 
-			logged_exceptions.insert(trace_hash);
+				logged_exceptions.insert(trace_hash);
+			}
 		}
 
-		if (exception_info->ExceptionRecord->ExceptionInformation[0] == EXCEPTION_EXECUTE_FAULT)
+		const bool is_execute_fault =
+			exception_code == EXCEPTION_ACCESS_VIOLATION
+			&& exception_info->ExceptionRecord->NumberParameters >= 1
+			&& exception_info->ExceptionRecord->ExceptionInformation[0] == EXCEPTION_EXECUTE_FAULT;
+
+		if (is_execute_fault)
 		{
 			auto return_address_ptr = (uint64_t*)exception_info->ContextRecord->Rsp;
 			if (IsBadReadPtr(reinterpret_cast<void*>(return_address_ptr), 8))

--- a/src/core/scripting/LuaScript.cpp
+++ b/src/core/scripting/LuaScript.cpp
@@ -104,7 +104,7 @@ namespace YimMenu
 		for (int i = 0; i < m_Resources.size(); i++)
 		{
 			if (!m_Resources[i].size())
-				return;
+				continue;
 
 			auto type = LuaManager::GetResourceType(i);
 			type->Lock();
@@ -121,7 +121,7 @@ namespace YimMenu
 		for (int i = 0; i < m_Resources.size(); i++)
 		{
 			if (!m_Resources[i].size())
-				return;
+				continue;
 
 			auto type = LuaManager::GetResourceType(i);
 			type->Lock();
@@ -158,8 +158,8 @@ namespace YimMenu
 		}
 
 		// we should have a function in the top of stack
-		CallFunction(0, 0);
-		m_LoadState = LoadState::RUNNING;
+		if (CallFunction(0, 0))
+			m_LoadState = LoadState::RUNNING;
 	}
 
 	LuaScript::~LuaScript()

--- a/src/core/settings/IStateSerializer.hpp
+++ b/src/core/settings/IStateSerializer.hpp
@@ -5,7 +5,7 @@ namespace YimMenu
 	class IStateSerializer
 	{
 		std::string m_SerComponentName;
-		bool m_IsDirty;
+		std::atomic_bool m_IsDirty;
 
 	public:
 		IStateSerializer(const std::string& name);
@@ -15,23 +15,23 @@ namespace YimMenu
 		inline void SaveState(nlohmann::json& state)
 		{
 			SaveStateImpl(state);
-			m_IsDirty = false;
+			m_IsDirty.store(false, std::memory_order_release);
 		}
 
 		inline void LoadState(nlohmann::json& state)
 		{
 			LoadStateImpl(state);
-			m_IsDirty = false;
+			m_IsDirty.store(false, std::memory_order_release);
 		}
 
 		inline bool IsStateDirty()
 		{
-			return m_IsDirty;
+			return m_IsDirty.load(std::memory_order_acquire);
 		}
 
 		inline void MarkStateDirty()
 		{
-			m_IsDirty = true;
+			m_IsDirty.store(true, std::memory_order_release);
 		}
 
 		inline const std::string& GetSerializerComponentName()

--- a/src/core/settings/Settings.cpp
+++ b/src/core/settings/Settings.cpp
@@ -8,6 +8,23 @@ namespace YimMenu
 {
 	namespace
 	{
+		bool ReadJson(const std::filesystem::path& path, nlohmann::json& output)
+		{
+			std::ifstream file(path);
+			if (!file)
+				return false;
+
+			try
+			{
+				file >> output;
+				return output.is_object();
+			}
+			catch (const std::exception&)
+			{
+				return false;
+			}
+		}
+
 		bool WriteAtomically(const std::filesystem::path& destination, std::string_view contents)
 		{
 			auto temporary = destination;
@@ -55,18 +72,24 @@ namespace YimMenu
 			return;
 		}
 
-		std::ifstream file(m_SettingsFile);
-
-		try
+		if (!ReadJson(m_SettingsFile, m_Json))
 		{
-			file >> m_Json;
-			file.close();
-		}
-		catch (std::exception&)
-		{
-			LOG(WARNING) << "Detected corrupt settings, resetting settings...";
-			Reset();
-			return;
+			auto backup = m_SettingsFile;
+			backup += ".bak";
+			if (ReadJson(backup, m_Json))
+			{
+				LOG(WARNING) << "Detected corrupt settings, recovered the previous backup";
+				std::error_code ec;
+				std::filesystem::copy_file(backup, m_SettingsFile, std::filesystem::copy_options::overwrite_existing, ec);
+				if (ec)
+					LOGF(FATAL, "Recovered settings in memory but could not restore the file: {}", ec.message());
+			}
+			else
+			{
+				LOG(WARNING) << "Detected corrupt settings without a valid backup, resetting settings...";
+				Reset();
+				return;
+			}
 		}
 
 		for (auto& serializer : m_StateSerializers)

--- a/src/core/settings/Settings.cpp
+++ b/src/core/settings/Settings.cpp
@@ -6,6 +6,38 @@
 
 namespace YimMenu
 {
+	namespace
+	{
+		bool WriteAtomically(const std::filesystem::path& destination, std::string_view contents)
+		{
+			auto temporary = destination;
+			temporary += ".tmp";
+			auto backup = destination;
+			backup += ".bak";
+
+			{
+				std::ofstream file(temporary, std::ios::binary | std::ios::trunc);
+				if (!file)
+					return false;
+				file.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+				file.flush();
+				if (!file)
+					return false;
+			}
+
+			const bool replaced = std::filesystem::exists(destination)
+				? ReplaceFileW(destination.c_str(), temporary.c_str(), backup.c_str(), REPLACEFILE_WRITE_THROUGH, nullptr, nullptr)
+				: MoveFileExW(temporary.c_str(), destination.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+
+			if (!replaced)
+			{
+				std::error_code ec;
+				std::filesystem::remove(temporary, ec);
+			}
+			return replaced;
+		}
+	}
+
 	Settings::Settings() :
 	    m_SettingsFile(),
 	    m_StateSerializers(),
@@ -63,9 +95,8 @@ namespace YimMenu
 				if (serializer->IsStateDirty())
 					SaveComponentImpl(serializer);
 
-			std::ofstream file(m_SettingsFile, std::ios::out | std::ios::trunc);
-			file << m_Json.dump(4);
-			file.close();
+			if (!WriteAtomically(m_SettingsFile, m_Json.dump(4)))
+				LOGF(FATAL, "Failed to save settings atomically: error {}", GetLastError());
 		}
 	}
 
@@ -106,9 +137,8 @@ namespace YimMenu
 
 	void Settings::Reset()
 	{
-		std::ofstream file(m_SettingsFile, std::ios::out | std::ios::trunc);
-		file << "{}" << std::endl;
-		file.close();
+		if (!WriteAtomically(m_SettingsFile, "{}\n"))
+			LOGF(FATAL, "Failed to reset settings atomically: error {}", GetLastError());
 		m_Json.clear();
 		m_InitialLoadDone = true;
 	}

--- a/src/game/backend/ProtectionTelemetry.cpp
+++ b/src/game/backend/ProtectionTelemetry.cpp
@@ -1,0 +1,72 @@
+#include "ProtectionTelemetry.hpp"
+
+namespace YimMenu
+{
+	namespace
+	{
+		constexpr std::array<std::string_view, static_cast<std::size_t>(ProtectionTelemetry::Event::Count)> EventNames{
+			"Malformed packed-event container",
+			"Malformed packed event",
+			"Malformed packed-reliables container",
+			"Malformed BattlEye command",
+			"Malformed script event",
+			"Kick message blocked",
+			"Bounty blocked",
+			"Text-label SMS blocked",
+			"Unauthorized CEO kick blocked",
+			"Interior control blocked",
+		};
+	}
+
+	ProtectionTelemetry::ProtectionTelemetry() :
+	    m_StartedAt(std::chrono::steady_clock::now())
+	{
+	}
+
+	ProtectionTelemetry& ProtectionTelemetry::GetInstance()
+	{
+		static ProtectionTelemetry instance;
+		return instance;
+	}
+
+	void ProtectionTelemetry::Increment(Event event)
+	{
+		auto& instance = GetInstance();
+		const auto index = static_cast<std::size_t>(event);
+		instance.m_Counters[index].fetch_add(1, std::memory_order_relaxed);
+		const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+		instance.m_LastSeenMilliseconds[index].store(now, std::memory_order_relaxed);
+	}
+
+	ProtectionTelemetry::Snapshot ProtectionTelemetry::GetSnapshot()
+	{
+		auto& instance = GetInstance();
+		Snapshot result{};
+		const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+		for (std::size_t i = 0; i < result.size(); ++i)
+		{
+			const auto last_seen = instance.m_LastSeenMilliseconds[i].load(std::memory_order_relaxed);
+			result[i] = {
+				static_cast<Event>(i),
+				EventNames[i],
+				instance.m_Counters[i].load(std::memory_order_relaxed),
+				last_seen > 0 ? std::optional{std::chrono::duration_cast<std::chrono::seconds>(std::chrono::milliseconds(now - last_seen))} : std::nullopt,
+			};
+		}
+		return result;
+	}
+
+	void ProtectionTelemetry::Reset()
+	{
+		auto& instance = GetInstance();
+		for (auto& counter : instance.m_Counters)
+			counter.store(0, std::memory_order_relaxed);
+		for (auto& last_seen : instance.m_LastSeenMilliseconds)
+			last_seen.store(0, std::memory_order_relaxed);
+	}
+
+	std::chrono::seconds ProtectionTelemetry::Uptime()
+	{
+		return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - GetInstance().m_StartedAt);
+	}
+}

--- a/src/game/backend/ProtectionTelemetry.hpp
+++ b/src/game/backend/ProtectionTelemetry.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace YimMenu
+{
+	class ProtectionTelemetry
+	{
+	public:
+		enum class Event : std::size_t
+		{
+			MalformedPackedEvents,
+			MalformedPackedEvent,
+			MalformedPackedReliables,
+			MalformedBattlEyeCommand,
+			MalformedScriptEvent,
+			BlockedKickMessage,
+			BlockedBounty,
+			BlockedTextLabelSms,
+			BlockedCeoKick,
+			BlockedInteriorControl,
+			Count
+		};
+
+		struct Entry
+		{
+			Event m_Event;
+			std::string_view m_Name;
+			std::uint64_t m_Count;
+			std::optional<std::chrono::seconds> m_LastSeenAgo;
+		};
+
+		using Snapshot = std::array<Entry, static_cast<std::size_t>(Event::Count)>;
+
+		static void Increment(Event event);
+		static Snapshot GetSnapshot();
+		static void Reset();
+		static std::chrono::seconds Uptime();
+
+	private:
+		ProtectionTelemetry();
+		static ProtectionTelemetry& GetInstance();
+
+		std::array<std::atomic_uint64_t, static_cast<std::size_t>(Event::Count)> m_Counters{};
+		std::array<std::atomic_int64_t, static_cast<std::size_t>(Event::Count)> m_LastSeenMilliseconds{};
+		std::chrono::steady_clock::time_point m_StartedAt;
+	};
+}

--- a/src/game/frontend/items/Items.hpp
+++ b/src/game/frontend/items/Items.hpp
@@ -108,7 +108,7 @@ namespace YimMenu
 	private:
 		ListCommand* m_Command;
 		std::optional<std::string> m_LabelOverride;
-		std::optional<int> m_ItemWidth = std::nullopt;
+		std::optional<float> m_ItemWidth = std::nullopt;
 		std::optional<std::string> m_SelectedItem = std::nullopt;
 	};
 

--- a/src/game/frontend/submenus/Network.cpp
+++ b/src/game/frontend/submenus/Network.cpp
@@ -1,10 +1,14 @@
 #include "Network.hpp"
 #include "core/backend/FiberPool.hpp"
+#include "core/backend/PatternCache.hpp"
 #include "core/frontend/Notifications.hpp"
+#include "game/backend/AnticheatBypass.hpp"
+#include "game/backend/ProtectionTelemetry.hpp"
 #include "game/frontend/items/Items.hpp"
 #include "game/frontend/submenus/Network/SavedPlayers.hpp"
 #include "game/frontend/submenus/Network/RandomEvents.hpp"
 #include "game/gta/Network.hpp"
+#include "game/pointers/Pointers.hpp"
 
 namespace YimMenu::Submenus
 {
@@ -133,8 +137,107 @@ namespace YimMenu::Submenus
 		matchmakingSrvGroup->AddItem(std::move(srvMultiplex));
 		spoofing->AddItem(matchmakingSrvGroup);
 
+		auto diagnostics = std::make_shared<Category>("Diagnostics");
+		diagnostics->AddItem(std::make_shared<ImGuiItem>([] {
+			const auto game_version = Pointers.GameVersion ? Pointers.GameVersion : "Unavailable";
+			const auto online_version = Pointers.OnlineVersion ? Pointers.OnlineVersion : "Unavailable";
+			const bool session_started = Pointers.IsSessionStarted && *Pointers.IsSessionStarted;
+			const auto uptime = ProtectionTelemetry::Uptime();
+			const auto hours = std::chrono::duration_cast<std::chrono::hours>(uptime);
+			const auto minutes = std::chrono::duration_cast<std::chrono::minutes>(uptime - hours);
+			const auto seconds = uptime - hours - minutes;
+
+			ImGui::Text("Game version: %s", game_version);
+			ImGui::Text("Online version: %s", online_version);
+			ImGui::Text("Pattern cache: %s (%zu entries)", PatternCache::IsInitialized() ? "Ready" : "Unavailable", PatternCache::GetEntryCount());
+			ImGui::Text("Session: %s", session_started ? "Online" : "Offline");
+			ImGui::Text("BattlEye: %s", AnticheatBypass::IsBattlEyeRunning() ? "Running" : "Not running");
+			ImGui::Text("FSL: %s", AnticheatBypass::IsFSLLoaded() ? "Loaded" : "Not loaded");
+			if (AnticheatBypass::IsFSLLoaded())
+			{
+				ImGui::Text("FSL version: %d", AnticheatBypass::GetFSLVersion());
+				ImGui::Text("FSL local saves: %s", AnticheatBypass::IsFSLProvidingLocalSaves() ? "Available" : "Unavailable");
+				ImGui::Text("FSL BattlEye bypass: %s", AnticheatBypass::IsFSLProvidingBattlEyeBypass() ? "Available" : "Unavailable");
+			}
+			ImGui::Text("Runtime: %lldh %lldm %llds", hours.count(), minutes.count(), seconds.count());
+
+			if (!Pointers.GameVersion || !Pointers.OnlineVersion)
+				ImGui::TextColored(ImVec4(1.0f, 0.65f, 0.2f, 1.0f), "Compatibility warning: version pointers are unavailable.");
+			if (AnticheatBypass::IsBattlEyeRunning() && !AnticheatBypass::IsFSLProvidingBattlEyeBypass())
+				ImGui::TextColored(ImVec4(1.0f, 0.35f, 0.25f, 1.0f), "Safety warning: BattlEye is running without an FSL bypass.");
+
+			ImGui::SeparatorText("Protection telemetry");
+			ImGui::TextDisabled("Aggregate counts only; no player identifiers are retained.");
+			const auto snapshot = ProtectionTelemetry::GetSnapshot();
+			std::uint64_t total_events{};
+			for (const auto& entry : snapshot)
+				total_events += entry.m_Count;
+			ImGui::Text("Total protection events: %llu", static_cast<unsigned long long>(total_events));
+
+			if (ImGui::BeginTable("protection_telemetry", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp))
+			{
+				ImGui::TableSetupColumn("Event");
+				ImGui::TableSetupColumn("Count", ImGuiTableColumnFlags_WidthFixed, 90.0f);
+				ImGui::TableSetupColumn("Last seen", ImGuiTableColumnFlags_WidthFixed, 110.0f);
+				ImGui::TableHeadersRow();
+
+				for (const auto& entry : snapshot)
+				{
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0);
+					ImGui::TextUnformatted(entry.m_Name.data(), entry.m_Name.data() + entry.m_Name.size());
+					ImGui::TableSetColumnIndex(1);
+					ImGui::Text("%llu", static_cast<unsigned long long>(entry.m_Count));
+					ImGui::TableSetColumnIndex(2);
+					if (entry.m_LastSeenAgo)
+						ImGui::Text("%llds ago", entry.m_LastSeenAgo->count());
+					else
+						ImGui::TextUnformatted("Never");
+				}
+				ImGui::EndTable();
+			}
+
+			if (ImGui::Button("Reset telemetry"))
+				ProtectionTelemetry::Reset();
+			ImGui::SameLine();
+			if (ImGui::Button("Copy diagnostics"))
+			{
+				std::string report = std::format(
+					"YimMenuV2 diagnostics\n"
+					"Game version: {}\n"
+					"Online version: {}\n"
+					"Pattern cache: {} ({} entries)\n"
+					"Session: {}\n"
+					"BattlEye: {}\n"
+					"FSL: {}\n"
+					"Runtime: {}h {}m {}s\n"
+					"Protection telemetry:\n",
+					game_version,
+					online_version,
+					PatternCache::IsInitialized() ? "Ready" : "Unavailable",
+					PatternCache::GetEntryCount(),
+					session_started ? "Online" : "Offline",
+					AnticheatBypass::IsBattlEyeRunning() ? "Running" : "Not running",
+					AnticheatBypass::IsFSLLoaded() ? "Loaded" : "Not loaded",
+					hours.count(),
+					minutes.count(),
+					seconds.count());
+
+				for (const auto& entry : ProtectionTelemetry::GetSnapshot())
+					report += std::format(
+						"- {}: {} (last seen: {})\n",
+						entry.m_Name,
+						entry.m_Count,
+						entry.m_LastSeenAgo ? std::format("{}s ago", entry.m_LastSeenAgo->count()) : "never");
+
+				ImGui::SetClipboardText(report.c_str());
+				Notifications::Show("Diagnostics", "Copied privacy-safe diagnostics to the clipboard", NotificationType::Success);
+			}
+		}));
+
 		AddCategory(std::move(session));
 		AddCategory(std::move(spoofing));
+		AddCategory(std::move(diagnostics));
 		AddCategory(std::move(BuildSavedPlayersMenu()));
 		AddCategory(BuildRandomEventsMenu());
 	}

--- a/src/game/hooks/Network/HandleScriptedGameEvent.cpp
+++ b/src/game/hooks/Network/HandleScriptedGameEvent.cpp
@@ -1,4 +1,5 @@
 #include "game/backend/Self.hpp"
+#include "game/backend/ProtectionTelemetry.hpp"
 #include "game/hooks/Hooks.hpp"
 #include "game/pointers/Pointers.hpp"
 #include "types/network/netGameEvent.hpp"
@@ -32,7 +33,10 @@ namespace YimMenu::Hooks
 	bool Network::HandleScriptedGameEvent(Player player, CScriptedGameEvent& event)
 	{
 		if (event.m_ArgsSize < sizeof(std::int64_t) || event.m_ArgsSize > sizeof(event.m_Args) || event.m_ArgsSize % sizeof(std::int64_t) != 0)
+		{
+			ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedScriptEvent);
 			return false;
+		}
 
 		if (!CheckLuaScripts(player, event))
 			return false;
@@ -47,12 +51,13 @@ namespace YimMenu::Hooks
 
 			if (event.m_ArgsSize != SCRIPT_EVENT_BOUNTY::GetSize())
 			{
-				//player.AddDetection();
+				ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedScriptEvent);
 				return false;
 			}
 
 			if (bounty->Target == Self::GetPlayer().GetId())
 			{
+				ProtectionTelemetry::Increment(ProtectionTelemetry::Event::BlockedBounty);
 				return false;
 			}
 
@@ -60,17 +65,21 @@ namespace YimMenu::Hooks
 		}
 		case ScriptEventIndex::SendTextLabelSMS:
 		{
-			//player.AddDetection();
+			ProtectionTelemetry::Increment(ProtectionTelemetry::Event::BlockedTextLabelSms);
 			return false;
 		}
 		case ScriptEventIndex::CeoKick:
 		{
 			const auto local_id = Self::GetPlayer().GetId();
 			if (local_id < 0 || local_id >= 32 || player.GetId() < 0 || player.GetId() >= 32)
+			{
+				ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedScriptEvent);
 				return false;
+			}
 
 			if (player.GetId() != GPBD_FM_3::Get()->Entries[local_id].BossGoon.Boss)
 			{
+				ProtectionTelemetry::Increment(ProtectionTelemetry::Event::BlockedCeoKick);
 				return false;
 			}
 
@@ -82,13 +91,13 @@ namespace YimMenu::Hooks
 
 			if (interior_control->Interior < 0 || interior_control->Interior >= static_cast<int>(eSimpleInteriorIndex::SIMPLE_INTERIOR_MAX)) // the upper bound will change after an update
 			{
-				// null function kick
+				ProtectionTelemetry::Increment(ProtectionTelemetry::Event::BlockedInteriorControl);
 				return false;
 			}
 
 			if (!interior_control->GoonsOnly)
 			{
-				// send to interior
+				ProtectionTelemetry::Increment(ProtectionTelemetry::Event::BlockedInteriorControl);
 				return false;
 			}
 

--- a/src/game/hooks/Network/HandleScriptedGameEvent.cpp
+++ b/src/game/hooks/Network/HandleScriptedGameEvent.cpp
@@ -31,6 +31,9 @@ namespace YimMenu::Hooks
 
 	bool Network::HandleScriptedGameEvent(Player player, CScriptedGameEvent& event)
 	{
+		if (event.m_ArgsSize < sizeof(std::int64_t) || event.m_ArgsSize > sizeof(event.m_Args) || event.m_ArgsSize % sizeof(std::int64_t) != 0)
+			return false;
+
 		if (!CheckLuaScripts(player, event))
 			return false;
 
@@ -62,7 +65,11 @@ namespace YimMenu::Hooks
 		}
 		case ScriptEventIndex::CeoKick:
 		{
-			if (player.GetId() != GPBD_FM_3::Get()->Entries[Self::GetPlayer().GetId()].BossGoon.Boss)
+			const auto local_id = Self::GetPlayer().GetId();
+			if (local_id < 0 || local_id >= 32 || player.GetId() < 0 || player.GetId() >= 32)
+				return false;
+
+			if (player.GetId() != GPBD_FM_3::Get()->Entries[local_id].BossGoon.Boss)
 			{
 				return false;
 			}

--- a/src/game/hooks/Network/ReceiveNetMessage.cpp
+++ b/src/game/hooks/Network/ReceiveNetMessage.cpp
@@ -67,8 +67,8 @@ namespace YimMenu::Hooks
 			uint32_t count = buffer.Read<uint32_t>(5);
 			uint32_t buffer_size = buffer.Read<uint32_t>(15);
 
-			if (buffer_size > 7296)
-				buffer_size = 7296;
+			if (buffer_size > 7296 || !buffer.CanRead(buffer_size))
+				break;
 
 			int remaining = buffer_size;
 
@@ -85,9 +85,13 @@ namespace YimMenu::Hooks
 					buffer.Read<uint32_t>(16);
 
 				char event_data[4096 + 1];
+				if (event_data_size > sizeof(event_data) * 8 || !buffer.CanRead(event_data_size))
+					break;
+
 				if (event_data_size)
 				{
-					buffer.ReadArray(event_data, event_data_size);
+					if (!buffer.ReadArray(event_data, event_data_size))
+						break;
 				}
 
 				rage::datBitBuffer event_buffer(event_data, sizeof(event_data), true);
@@ -171,7 +175,8 @@ namespace YimMenu::Hooks
 				int size = buffer.Read<int>(11);
 				bool from_client = buffer.Read<bool>(1);
 				buffer.Seek(4); // normalize before we read
-				buffer.ReadArrayBytes(&data, size);
+				if (size <= 0 || size > static_cast<int>(sizeof(data)) || !buffer.ReadArrayBytes(data, size))
+					return;
 
 				if (from_client)
 					break;

--- a/src/game/hooks/Network/ReceiveNetMessage.cpp
+++ b/src/game/hooks/Network/ReceiveNetMessage.cpp
@@ -2,6 +2,7 @@
 #include "core/scripting/LuaManager.hpp"
 #include "game/backend/AnticheatBypass.hpp"
 #include "game/backend/Players.hpp"
+#include "game/backend/ProtectionTelemetry.hpp"
 #include "game/frontend/ChatDisplay.hpp"
 #include "game/hooks/Hooks.hpp"
 #include "game/gta/Packet.hpp"
@@ -68,7 +69,10 @@ namespace YimMenu::Hooks
 			uint32_t buffer_size = buffer.Read<uint32_t>(15);
 
 			if (buffer_size > 7296 || !buffer.CanRead(buffer_size))
+			{
+				ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedPackedEvents);
 				break;
+			}
 
 			int remaining = buffer_size;
 
@@ -84,14 +88,24 @@ namespace YimMenu::Hooks
 				if (buffer.Read<bool>(1))
 					buffer.Read<uint32_t>(16);
 
+				const auto header_size = buffer.m_BitsRead - bits_read;
 				char event_data[4096 + 1];
-				if (event_data_size > sizeof(event_data) * 8 || !buffer.CanRead(event_data_size))
+				if (header_size > static_cast<std::uint32_t>(remaining)
+					|| event_data_size > static_cast<std::uint32_t>(remaining) - header_size
+					|| event_data_size > sizeof(event_data) * 8
+					|| !buffer.CanRead(event_data_size))
+				{
+					ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedPackedEvent);
 					break;
+				}
 
 				if (event_data_size)
 				{
 					if (!buffer.ReadArray(event_data, event_data_size))
+					{
+						ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedPackedEvent);
 						break;
+					}
 				}
 
 				rage::datBitBuffer event_buffer(event_data, sizeof(event_data), true);
@@ -114,13 +128,27 @@ namespace YimMenu::Hooks
 			{
 				auto timestamp = buffer.Read<std::uint32_t>(32);
 				if (auto num_msgs = buffer.Read<int>(5))
-					buffer.Seek(buffer.Read<std::uint32_t>(13));
+				{
+					const auto size = buffer.Read<std::uint32_t>(13);
+					if (!buffer.Seek(size))
+					{
+						ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedPackedReliables);
+						return;
+					}
+				}
 			}
 
 			if ((flags & 2) != 0)
 			{
 				if (auto num_msgs = buffer.Read<int>(5))
-					buffer.Seek(buffer.Read<std::uint32_t>(13));
+				{
+					const auto size = buffer.Read<std::uint32_t>(13);
+					if (!buffer.Seek(size))
+					{
+						ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedPackedReliables);
+						return;
+					}
+				}
 			}
 
 			if ((flags & 4) != 0)
@@ -129,7 +157,14 @@ namespace YimMenu::Hooks
 				{
 					auto sz = buffer.Read<std::uint32_t>(13);
 					auto pos_now = buffer.m_BitsRead;
-					while (pos_now + sz > buffer.m_BitsRead)
+					if (!buffer.CanRead(sz) || sz % 18 != 0)
+					{
+						ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedPackedReliables);
+						return;
+					}
+
+					const auto end = pos_now + sz;
+					while (buffer.m_BitsRead < end)
 					{
 						auto id = buffer.Read<std::uint16_t>(13);
 						auto token = buffer.Read<int>(5);
@@ -164,7 +199,10 @@ namespace YimMenu::Hooks
 		case rage::netMessage::Type::KickPlayer:
 		{
 			if (!AnticheatBypass::IsFSLProvidingBattlEyeBypass())
+			{
+				ProtectionTelemetry::Increment(ProtectionTelemetry::Event::BlockedKickMessage);
 				return;
+			}
 			break;
 		}
 		case rage::netMessage::Type::BattlEyeCmd:
@@ -176,7 +214,10 @@ namespace YimMenu::Hooks
 				bool from_client = buffer.Read<bool>(1);
 				buffer.Seek(4); // normalize before we read
 				if (size <= 0 || size > static_cast<int>(sizeof(data)) || !buffer.ReadArrayBytes(data, size))
+				{
+					ProtectionTelemetry::Increment(ProtectionTelemetry::Event::MalformedBattlEyeCommand);
 					return;
+				}
 
 				if (from_client)
 					break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,7 +91,7 @@ namespace YimMenu
 		while (g_Running)
 		{
 			Settings::Tick();
-			std::this_thread::yield();
+			std::this_thread::sleep_for(10ms);
 		}
 
 		LOG(INFO) << "Unloading";

--- a/src/types/network/netGameEvent.cpp
+++ b/src/types/network/netGameEvent.cpp
@@ -9,8 +9,7 @@ bool CScriptedGameEvent::Deserialize(rage::datBitBuffer& buffer)
 	if (m_ArgsSize > sizeof(m_Args))
 		return false;
 
-	buffer.ReadArrayBytes(m_Args, m_ArgsSize);
-	return true;
+	return buffer.ReadArrayBytes(m_Args, m_ArgsSize);
 }
 
 void CNetworkIncrementStatEvent::Deserialize(rage::datBitBuffer& buffer)

--- a/src/types/rage/datBitBuffer.hpp
+++ b/src/types/rage/datBitBuffer.hpp
@@ -2,6 +2,7 @@
 #include "vector.hpp"
 
 #include <cstdint>
+#include <limits>
 
 namespace rage
 {
@@ -285,6 +286,16 @@ namespace rage
 			return m_FlagBits & 2;
 		}
 
+		[[nodiscard]] bool CanRead(std::uint32_t bits) const
+		{
+			return IsReadBuffer() && bits <= m_MaxBit && m_BitsRead <= m_MaxBit - bits;
+		}
+
+		[[nodiscard]] bool CanWrite(std::uint32_t bits) const
+		{
+			return !IsReadBuffer() && bits <= m_MaxBit && m_BitsRead <= m_MaxBit - bits;
+		}
+
 		void Seek(int bits)
 		{
 			m_BitsRead += bits;
@@ -330,10 +341,14 @@ namespace rage
 
 		inline bool ReadQword(uint64_t* out, int size)
 		{
+			if (!out || size < 0 || size > 64)
+				return false;
+
+			*out = 0;
 			if (size <= 32)
 				return ReadDword(reinterpret_cast<int*>(out), size);
 
-			return ReadDword(reinterpret_cast<int*>(out), 32) && !ReadDword(reinterpret_cast<int*>(out) + 1, size - 32);
+			return ReadDword(reinterpret_cast<int*>(out), 32) && ReadDword(reinterpret_cast<int*>(out) + 1, size - 32);
 		}
 
 		inline bool WriteQword(uint64_t value, int size)
@@ -349,20 +364,26 @@ namespace rage
 
 		inline bool ReadInt64(int64_t* value, int size)
 		{
-			unsigned int last_bit{};
-			uint64_t rest{};
-
-			if (!ReadQword((uint64_t*)&last_bit, 1) || ReadQword(&rest, size - 1))
+			if (!value || size < 1 || size > 64)
 				return false;
 
-			*value = ((uint64_t)last_bit << 63) | rest ^ -(int64_t)last_bit;
+			uint64_t last_bit{};
+			uint64_t rest{};
+
+			if (!ReadQword(&last_bit, 1) || !ReadQword(&rest, size - 1))
+				return false;
+
+			*value = static_cast<int64_t>(rest ^ -static_cast<int64_t>(last_bit));
 			return true;
 		}
 
 		inline bool WriteInt64(int64_t value, int size)
 		{
-			auto last_bit = value >> 63;
-			if (!WriteQword(last_bit, 1) || !WriteQword((uint64_t)value ^ -(__int64)(unsigned int)last_bit, size - 1))
+			if (size < 1 || size > 64)
+				return false;
+
+			const uint64_t last_bit = value < 0 ? 1 : 0;
+			if (!WriteQword(last_bit, 1) || !WriteQword(static_cast<uint64_t>(value) ^ -last_bit, size - 1))
 				return false;
 
 			return true;
@@ -401,34 +422,40 @@ namespace rage
 				WriteQword(uint64_t(data), size);
 		}
 
-		void WriteArray(const void* array, int bits)
+		bool WriteArray(const void* array, int bits)
 		{
-			if (!IsReadBuffer())
-			{
-				if (!IsSizeCalculator())
-					CopyBits(reinterpret_cast<void*>(reinterpret_cast<std::uint64_t>(m_Data) + (m_BitOffset >> 3)), array, bits, m_BitsRead + (m_BitOffset & 7), 0);
-				Seek(bits);
-			}
+			if (!array || bits < 0 || !CanWrite(static_cast<std::uint32_t>(bits)))
+				return false;
+
+			if (!IsSizeCalculator())
+				CopyBits(reinterpret_cast<void*>(reinterpret_cast<std::uint64_t>(m_Data) + (m_BitOffset >> 3)), array, bits, m_BitsRead + (m_BitOffset & 7), 0);
+			Seek(bits);
+			return true;
 		}
 
-		void WriteArrayBytes(const void* array, int bytes)
+		bool WriteArrayBytes(const void* array, int bytes)
 		{
-			WriteArray(array, bytes * 8);
+			if (bytes < 0 || bytes > (std::numeric_limits<int>::max)() / 8)
+				return false;
+			return WriteArray(array, bytes * 8);
 		}
 
-		void ReadArray(void* array, int bits)
+		bool ReadArray(void* array, int bits)
 		{
-			if (!IsReadBuffer())
-				return;
+			if (!array || bits < 0 || !CanRead(static_cast<std::uint32_t>(bits)))
+				return false;
 
 			if (!IsSizeCalculator())
 				CopyBits(array, reinterpret_cast<void*>(reinterpret_cast<std::uint64_t>(m_Data) + (m_BitOffset >> 3)), bits, 0, m_BitsRead + (m_BitOffset & 7));
 			Seek(bits);
+			return true;
 		}
 
-		void ReadArrayBytes(void* array, int bytes)
+		bool ReadArrayBytes(void* array, int bytes)
 		{
-			ReadArray(array, bytes * 8);
+			if (bytes < 0 || bytes > (std::numeric_limits<int>::max)() / 8)
+				return false;
+			return ReadArray(array, bytes * 8);
 		}
 
 		void WriteString(const char* string, int max_len)
@@ -443,12 +470,18 @@ namespace rage
 
 		void ReadString(char* string, int max_len)
 		{
+			if (!string || max_len <= 0)
+				return;
+
 			auto extended = Read<bool>(1);
 			auto len = Read<int>(extended ? 15 : 7);
-			if (len <= max_len)
+			if (len > 0 && len <= max_len && ReadArrayBytes(string, len))
 			{
-				ReadArrayBytes(string, len);
 				string[len - 1] = 0;
+			}
+			else
+			{
+				string[0] = 0;
 			}
 		}
 
@@ -522,7 +555,7 @@ namespace rage
 
 		void AlignToByteBoundary()
 		{
-			Seek(((m_BitsRead + 7) >> 3) - m_BitsRead);
+			Seek((8 - (m_BitsRead & 7)) & 7);
 		}
 
 	public:

--- a/src/types/rage/datBitBuffer.hpp
+++ b/src/types/rage/datBitBuffer.hpp
@@ -296,8 +296,15 @@ namespace rage
 			return !IsReadBuffer() && bits <= m_MaxBit && m_BitsRead <= m_MaxBit - bits;
 		}
 
-		void Seek(int bits)
+		bool Seek(int bits)
 		{
+			if (bits < 0)
+				return false;
+
+			const auto amount = static_cast<std::uint32_t>(bits);
+			if (amount > m_MaxBit || m_BitsRead > m_MaxBit - amount)
+				return false;
+
 			m_BitsRead += bits;
 
 			if (IsReadBuffer())
@@ -310,12 +317,18 @@ namespace rage
 				if (m_BitsRead > m_CurBit)
 					m_CurBit = m_BitsRead;
 			}
+			return true;
 		}
 
 		inline bool ReadDword(int* out, int size)
 		{
-			if (IsSizeCalculator())
+			if (!out || size < 0 || size > 32 || IsSizeCalculator())
 				return false;
+			if (size == 0)
+			{
+				*out = 0;
+				return true;
+			}
 
 			if (m_BitsRead + size > (IsReadBuffer() ? m_MaxBit : m_CurBit))
 				return false;
@@ -327,8 +340,10 @@ namespace rage
 
 		inline bool WriteDword(int val, int size)
 		{
-			if (IsReadBuffer())
+			if (size < 0 || size > 32 || IsReadBuffer())
 				return false;
+			if (size == 0)
+				return true;
 
 			if (m_BitsRead + size > m_MaxBit)
 				return false;
@@ -353,6 +368,9 @@ namespace rage
 
 		inline bool WriteQword(uint64_t value, int size)
 		{
+			if (size < 0 || size > 64)
+				return false;
+
 			if (size <= 32)
 				return WriteDword(static_cast<uint32_t>(value), size);
 
@@ -426,6 +444,8 @@ namespace rage
 		{
 			if (!array || bits < 0 || !CanWrite(static_cast<std::uint32_t>(bits)))
 				return false;
+			if (bits == 0)
+				return true;
 
 			if (!IsSizeCalculator())
 				CopyBits(reinterpret_cast<void*>(reinterpret_cast<std::uint64_t>(m_Data) + (m_BitOffset >> 3)), array, bits, m_BitsRead + (m_BitOffset & 7), 0);
@@ -444,6 +464,8 @@ namespace rage
 		{
 			if (!array || bits < 0 || !CanRead(static_cast<std::uint32_t>(bits)))
 				return false;
+			if (bits == 0)
+				return true;
 
 			if (!IsSizeCalculator())
 				CopyBits(array, reinterpret_cast<void*>(reinterpret_cast<std::uint64_t>(m_Data) + (m_BitOffset >> 3)), bits, 0, m_BitsRead + (m_BitOffset & 7));
@@ -487,6 +509,9 @@ namespace rage
 
 		float ReadFloat(int size, float divisor)
 		{
+			if (size < 1 || size > 31)
+				return 0.0f;
+
 			int integer = Read<int>(size);
 
 			float max = (1 << size) - 1;
@@ -495,6 +520,9 @@ namespace rage
 
 		void WriteFloat(int size, float divisor, float value)
 		{
+			if (size < 1 || size > 31 || divisor == 0.0f)
+				return;
+
 			float max = (1 << size) - 1;
 			int integer = (int)((value / divisor) * max);
 
@@ -503,6 +531,9 @@ namespace rage
 
 		float ReadSignedFloat(int size, float divisor)
 		{
+			if (size < 2 || size > 32)
+				return 0.0f;
+
 			int integer = Read<int>(size, true);
 
 			float max = (1 << (size - 1)) - 1;
@@ -511,6 +542,9 @@ namespace rage
 
 		void WriteSignedFloat(int size, float divisor, float value)
 		{
+			if (size < 2 || size > 32 || divisor == 0.0f)
+				return;
+
 			float max = (1 << (size - 1)) - 1;
 			int integer = (int)((value / divisor) * max);
 

--- a/tests/datBitBufferTests.cpp
+++ b/tests/datBitBufferTests.cpp
@@ -59,8 +59,20 @@ int main()
 	{
 		std::array<std::uint8_t, 2> storage{};
 		rage::datBitBuffer reader(storage.data(), static_cast<std::uint32_t>(storage.size()), true);
-		reader.Seek(3);
+		CHECK(reader.Seek(3));
 		reader.AlignToByteBoundary();
 		CHECK(reader.m_BitsRead == 8);
+		CHECK(!reader.Seek(-1));
+		CHECK(!reader.Seek(9));
+		CHECK(reader.m_BitsRead == 8);
+	}
+
+	{
+		std::array<std::uint8_t, 1> storage{};
+		rage::datBitBuffer reader(storage.data(), static_cast<std::uint32_t>(storage.size()), true);
+		std::uint64_t value{};
+		CHECK(!reader.ReadQword(&value, 65));
+		CHECK(!reader.ReadQword(nullptr, 8));
+		CHECK(reader.m_BitsRead == 0);
 	}
 }

--- a/tests/datBitBufferTests.cpp
+++ b/tests/datBitBufferTests.cpp
@@ -1,0 +1,66 @@
+#include "types/rage/datBitBuffer.hpp"
+
+#include <array>
+#include <cstdint>
+#include <iostream>
+
+#define CHECK(condition) \
+	do \
+	{ \
+		if (!(condition)) \
+			return __LINE__; \
+	} while (false)
+
+int main()
+{
+	{
+		std::array<std::uint8_t, 16> storage{};
+		rage::datBitBuffer writer(storage.data(), static_cast<std::uint32_t>(storage.size()));
+		constexpr std::uint64_t expected = 0xFEDCBA9876543210ULL;
+		CHECK(writer.WriteQword(expected, 64));
+
+		rage::datBitBuffer reader(storage.data(), static_cast<std::uint32_t>(storage.size()), true);
+		std::uint64_t actual{};
+		CHECK(reader.ReadQword(&actual, 64));
+		CHECK(actual == expected);
+	}
+
+	{
+		std::array<std::uint8_t, 16> storage{};
+		rage::datBitBuffer writer(storage.data(), static_cast<std::uint32_t>(storage.size()));
+		CHECK(writer.WriteInt64(-42, 64));
+
+		rage::datBitBuffer reader(storage.data(), static_cast<std::uint32_t>(storage.size()), true);
+		std::int64_t actual{};
+		CHECK(reader.ReadInt64(&actual, 64));
+		if (actual != -42)
+		{
+			std::cerr << "signed 64-bit round trip produced " << actual << '\n';
+			return __LINE__;
+		}
+	}
+
+	{
+		std::array<std::uint8_t, 2> storage{0xAA, 0x55};
+		std::array<std::uint8_t, 3> destination{};
+		rage::datBitBuffer reader(storage.data(), static_cast<std::uint32_t>(storage.size()), true);
+		CHECK(!reader.ReadArrayBytes(destination.data(), static_cast<int>(destination.size())));
+		CHECK(reader.m_BitsRead == 0);
+	}
+
+	{
+		std::array<std::uint8_t, 2> storage{};
+		std::array<std::uint8_t, 3> source{1, 2, 3};
+		rage::datBitBuffer writer(storage.data(), static_cast<std::uint32_t>(storage.size()));
+		CHECK(!writer.WriteArrayBytes(source.data(), static_cast<int>(source.size())));
+		CHECK(writer.m_BitsRead == 0);
+	}
+
+	{
+		std::array<std::uint8_t, 2> storage{};
+		rage::datBitBuffer reader(storage.data(), static_cast<std::uint32_t>(storage.size()), true);
+		reader.Seek(3);
+		reader.AlignToByteBoundary();
+		CHECK(reader.m_BitsRead == 8);
+	}
+}

--- a/tests/protectionTelemetryTests.cpp
+++ b/tests/protectionTelemetryTests.cpp
@@ -1,0 +1,45 @@
+#include "game/backend/ProtectionTelemetry.hpp"
+
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#define CHECK(condition) \
+	do \
+	{ \
+		if (!(condition)) \
+			return __LINE__; \
+	} while (false)
+
+int main()
+{
+	using Telemetry = YimMenu::ProtectionTelemetry;
+	constexpr auto Event = Telemetry::Event::MalformedPackedEvent;
+	constexpr std::uint64_t ThreadCount = 8;
+	constexpr std::uint64_t IncrementsPerThread = 1'000;
+
+	Telemetry::Reset();
+	std::vector<std::thread> workers;
+	workers.reserve(ThreadCount);
+	for (std::uint64_t i = 0; i < ThreadCount; ++i)
+	{
+		workers.emplace_back([] {
+			for (std::uint64_t increment = 0; increment < IncrementsPerThread; ++increment)
+				Telemetry::Increment(Event);
+		});
+	}
+	for (auto& worker : workers)
+		worker.join();
+
+	const auto snapshot = Telemetry::GetSnapshot();
+	const auto& entry = snapshot[static_cast<std::size_t>(Event)];
+	CHECK(entry.m_Count == ThreadCount * IncrementsPerThread);
+	CHECK(entry.m_LastSeenAgo.has_value());
+	CHECK(entry.m_LastSeenAgo->count() <= 1);
+	CHECK(Telemetry::Uptime().count() >= 0);
+
+	Telemetry::Reset();
+	const auto reset_entry = Telemetry::GetSnapshot()[static_cast<std::size_t>(Event)];
+	CHECK(reset_entry.m_Count == 0);
+	CHECK(!reset_entry.m_LastSeenAgo.has_value());
+}


### PR DESCRIPTION
## Summary

- bounds-check bit-buffer reads, writes, seeks, strings, floats, and network-controlled payload sizes
- validate scripted events, packed events, packed reliables, and BattlEye commands before accessing their data
- add a privacy-safe Network → Diagnostics panel with compatibility state, FSL capabilities, protection totals, last-seen timestamps, reset, and clipboard export
- recover corrupt settings from an atomic backup and make serializer dirty flags thread-safe
- replace the raw pattern cache with a bounded, versioned, atomically replaced format
- fix Lua resource lifecycle, hotkey edge handling, exception logging synchronization, main-loop CPU use, and UI width narrowing warnings
- add bit-buffer and concurrent telemetry regression tests and run them in Windows CI

## Why

Several network-controlled lengths were trusted before packet and destination bounds were checked. The bit-buffer implementation also contained incorrect 64-bit and signed serialization logic. Persistence paths could leave corrupt settings or cache data after interrupted writes, while there was no user-facing way to inspect compatibility or protection activity.

## Impact

Malformed packets are rejected without overrunning buffers or hanging parsers. Users gain an aggregate diagnostics view that stores no player identifiers and can copy a support report directly to the clipboard. Settings can recover from their last known-good backup, the pattern cache validates its format, and runtime state updates are safer across threads.

## Validation

- configured with CMake using MSVC 19.44
- built `YimMenuV2.dll` successfully
- `dat_bit_buffer_tests`: passed
- `protection_telemetry_tests`: passed, including concurrent increments
- 2/2 CTest tests passed