### PR TITLE
feat: Add Nightclub automation and payout loops

### DIFF
--- a/src/game/features/recovery/Nightclub.cpp
+++ b/src/game/features/recovery/Nightclub.cpp
@@ -1,0 +1,57 @@
+#include "core/commands/Command.hpp"
+#include "core/commands/LoopedCommand.hpp"
+#include "core/commands/IntCommand.hpp"
+#include "game/backend/Self.hpp"
+#include "game/gta/ScriptGlobal.hpp"
+#include "game/gta/Stats.hpp"
+#include "game/pointers/Pointers.hpp"
+#include "types/script/globals/GPBD_FM.hpp"
+
+namespace YimMenu::Features
+{
+	class MaxNightclubPopularityCommand : public Command
+	{
+		using Command::Command;
+
+		virtual void OnCall() override
+		{
+			if (!*Pointers.IsSessionStarted)
+				return;
+
+			// Set popularity to max (1.0f)
+			GPBD_FM::Get()->Entries[Self::GetPlayer().GetId()].PropertyData.NightclubData.Popularity = 1.0f;
+		}
+	};
+
+	static MaxNightclubPopularityCommand _MaxNightclubPopularity{"maxnightclubpopularity", "Max Nightclub Popularity", "Sets your nightclub popularity to 100%."};
+
+	static IntCommand _NightclubLoopInterval{"nightclubloopinterval", "Loop Interval (ms)", "The interval between popularity maintenance and safe collection.", 1000, 30000, 7000};
+
+	class KeepNightclubPopularityLoop : public LoopedCommand
+	{
+		using LoopedCommand::LoopedCommand;
+
+		virtual void OnTick() override
+		{
+			if (!*Pointers.IsSessionStarted)
+				return;
+
+			static auto last_run = std::chrono::steady_clock::now();
+			auto now = std::chrono::steady_clock::now();
+
+			if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_run).count() >= _NightclubLoopInterval.GetState())
+			{
+				// Set popularity to max
+				Stats::SetInt("mpx_club_popularity", 1000);
+				Stats::SetInt("mpx_club_pay_time_left", -1);
+
+				// Collect safe earnings
+				*ScriptGlobal(2708943).As<BOOL*>() = TRUE;
+				
+				last_run = now;
+			}
+		}
+	};
+
+	static KeepNightclubPopularityLoop _KeepNightclubPopularity{"keepnightclubpopularity", "Keep Nightclub Popularity Max", "Continuously sets nightclub popularity and collects earnings."};
+}

--- a/src/game/features/recovery/Nightclub.cpp
+++ b/src/game/features/recovery/Nightclub.cpp
@@ -25,7 +25,9 @@ namespace YimMenu::Features
 
 	static MaxNightclubPopularityCommand _MaxNightclubPopularity{"maxnightclubpopularity", "Max Nightclub Popularity", "Sets your nightclub popularity to 100%."};
 
-	static IntCommand _NightclubLoopInterval{"nightclubloopinterval", "Loop Interval (ms)", "The interval between popularity maintenance and safe collection.", 1000, 30000, 7000};
+	static IntCommand _NightclubPopularityInterval{"nightclubpopularityinterval", "Popularity Loop Interval (min)", "The interval between popularity maintenance.", 0, 60, 5};
+	static IntCommand _NightclubSafeInterval{"nightclubsafeinterval", "Safe Collection Interval (min)", "The interval between safe collection.", 0, 60, 5};
+	static IntCommand _NightclubPayTimeInterval{"nightclubpaytimeinterval", "Pay Time Reset Interval (min)", "The interval between pay time reset.", 0, 60, 5};
 
 	class KeepNightclubPopularityLoop : public LoopedCommand
 	{
@@ -36,22 +38,61 @@ namespace YimMenu::Features
 			if (!*Pointers.IsSessionStarted)
 				return;
 
-			static auto last_run = std::chrono::steady_clock::now();
-			auto now = std::chrono::steady_clock::now();
+			static auto last_run = std::chrono::steady_clock::now() - std::chrono::hours(1);
+			auto now             = std::chrono::steady_clock::now();
 
-			if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_run).count() >= _NightclubLoopInterval.GetState())
+			if (std::chrono::duration_cast<std::chrono::minutes>(now - last_run).count() >= _NightclubPopularityInterval.GetState())
 			{
-				// Set popularity to max
 				Stats::SetInt("mpx_club_popularity", 1000);
-				Stats::SetInt("mpx_club_pay_time_left", -1);
-
-				// Collect safe earnings
-				*ScriptGlobal(2708943).As<BOOL*>() = TRUE;
-				
 				last_run = now;
 			}
 		}
 	};
 
-	static KeepNightclubPopularityLoop _KeepNightclubPopularity{"keepnightclubpopularity", "Keep Nightclub Popularity Max", "Continuously sets nightclub popularity and collects earnings."};
+	class AutoCollectNightclubSafeLoop : public LoopedCommand
+	{
+		using LoopedCommand::LoopedCommand;
+
+		virtual void OnTick() override
+		{
+			if (!*Pointers.IsSessionStarted)
+				return;
+
+			static auto last_run = std::chrono::steady_clock::now() - std::chrono::hours(1);
+			auto now             = std::chrono::steady_clock::now();
+
+			if (std::chrono::duration_cast<std::chrono::minutes>(now - last_run).count() >= _NightclubSafeInterval.GetState())
+			{
+				if (GPBD_FM::Get()->Entries[Self::GetPlayer().GetId()].PropertyData.NightclubData.SafeCashValue >= 250000)
+				{
+					*ScriptGlobal(2708943).As<BOOL*>() = TRUE;
+				}
+				last_run = now;
+			}
+		}
+	};
+
+	class AutoResetNightclubPayTimeLoop : public LoopedCommand
+	{
+		using LoopedCommand::LoopedCommand;
+
+		virtual void OnTick() override
+		{
+			if (!*Pointers.IsSessionStarted)
+				return;
+
+			static auto last_run = std::chrono::steady_clock::now() - std::chrono::hours(1);
+			auto now             = std::chrono::steady_clock::now();
+
+			if (std::chrono::duration_cast<std::chrono::minutes>(now - last_run).count() >= _NightclubPayTimeInterval.GetState())
+			{
+				Stats::SetInt("mpx_club_pay_time_left", -1);
+				last_run = now;
+			}
+		}
+	};
+
+	static KeepNightclubPopularityLoop _KeepNightclubPopularity{"keepnightclubpopularity", "Keep Nightclub Popularity Max", "Continuously sets nightclub popularity to 100%."};
+	static AutoCollectNightclubSafeLoop _AutoCollectNightclubSafe{"autocollectnightclubsafe", "Auto Collect Nightclub Safe", "Automatically collects nightclub safe earnings when full."};
+	static AutoResetNightclubPayTimeLoop _AutoResetNightclubPayTime{"autoresetnightclubpaytime", "Auto Reset Pay Time Left", "Automatically resets the nightclub pay time left."};
 }

--- a/src/game/features/recovery/Nightclub.cpp
+++ b/src/game/features/recovery/Nightclub.cpp
@@ -43,7 +43,8 @@ namespace YimMenu::Features
 
 			if (std::chrono::duration_cast<std::chrono::minutes>(now - last_run).count() >= _NightclubPopularityInterval.GetState())
 			{
-				Stats::SetInt("mpx_club_popularity", 1000);
+				Stats::SetInt("mp0_club_popularity", 1000);
+				Stats::SetInt("mp1_club_popularity", 1000);
 				last_run = now;
 			}
 		}
@@ -86,7 +87,8 @@ namespace YimMenu::Features
 
 			if (std::chrono::duration_cast<std::chrono::minutes>(now - last_run).count() >= _NightclubPayTimeInterval.GetState())
 			{
-				Stats::SetInt("mpx_club_pay_time_left", -1);
+				Stats::SetInt("mp0_club_pay_time_left", -1);
+				Stats::SetInt("mp1_club_pay_time_left", -1);
 				last_run = now;
 			}
 		}

--- a/src/game/frontend/submenus/Recovery.cpp
+++ b/src/game/frontend/submenus/Recovery.cpp
@@ -17,6 +17,7 @@ namespace YimMenu::Submenus
 
 		auto generalGroup = std::make_shared<Group>("General");
 		auto businessGroup = std::make_shared<Group>("General");
+		auto nightclubGroup = std::make_shared<Group>("Nightclub");
 		auto casinoSlots = std::make_shared<Group>("Slot Machines");
 		//auto casinoWheel = std::make_shared<Group>("Lucky Wheel");
 		//auto casinoBlackJack = std::make_shared<Group>("Blackjack");
@@ -33,11 +34,16 @@ namespace YimMenu::Submenus
 		businessGroup->AddItem(std::make_shared<ListCommandItem>("businesssafe"_J));
 		businessGroup->AddItem(std::make_shared<CommandItem>("claimsafeearnings"_J));
 
+		nightclubGroup->AddItem(std::make_shared<CommandItem>("maxnightclubpopularity"_J));
+		nightclubGroup->AddItem(std::make_shared<BoolCommandItem>("keepnightclubpopularity"_J));
+		nightclubGroup->AddItem(std::make_shared<IntCommandItem>("nightclubloopinterval"_J));
+
 		casinoSlots->AddItem(std::make_shared<BoolCommandItem>("casinomanipulaterigslotmachines"_J));
 		
 
 		main->AddItem(generalGroup);
 		businesses->AddItem(businessGroup);
+		businesses->AddItem(nightclubGroup);
 		casino->AddItem(casinoSlots);
 
 		AddCategory(std::move(main));

--- a/src/game/frontend/submenus/Recovery.cpp
+++ b/src/game/frontend/submenus/Recovery.cpp
@@ -36,7 +36,11 @@ namespace YimMenu::Submenus
 
 		nightclubGroup->AddItem(std::make_shared<CommandItem>("maxnightclubpopularity"_J));
 		nightclubGroup->AddItem(std::make_shared<BoolCommandItem>("keepnightclubpopularity"_J));
-		nightclubGroup->AddItem(std::make_shared<IntCommandItem>("nightclubloopinterval"_J));
+		nightclubGroup->AddItem(std::make_shared<IntCommandItem>("nightclubpopularityinterval"_J));
+		nightclubGroup->AddItem(std::make_shared<BoolCommandItem>("autocollectnightclubsafe"_J));
+		nightclubGroup->AddItem(std::make_shared<IntCommandItem>("nightclubsafeinterval"_J));
+		nightclubGroup->AddItem(std::make_shared<BoolCommandItem>("autoresetnightclubpaytime"_J));
+		nightclubGroup->AddItem(std::make_shared<IntCommandItem>("nightclubpaytimeinterval"_J));
 
 		casinoSlots->AddItem(std::make_shared<BoolCommandItem>("casinomanipulaterigslotmachines"_J));
 		


### PR DESCRIPTION
This PR introduces a set of quality of life features for Nightclub management. It automates repetitive tasks like collecting the safe and keeping popularity high, while also adding a customizable payout loop for quick money generation. I use it on my personal build and tested it on a fork.

## Features
- **Auto-Max Nightclub Popularity:** Automatically keeps the Nightclub popularity at maximum. Comes with an adjustable timer/delay to set how often the stat is refreshed.
- **Auto-Collect Nightclub Safe:** Automatically collects the money from the Nightclub safe once it reaches the maximum capacity of $250,000. Includes an adjustable interval for the checks.
- **Nightclub Payout Loop (Reset Payout):** Instantly resets the Nightclub daily payout. By combining this with an adjustable timer, it acts as an easy and fast money loop.

## UI Changes
- Added toggles and delay sliders for the new Nightclub features under the respective GUI tab.
