### PR TITLE
Vehicle Menu & Management Improvements

### DIFF
--- a/src/game/frontend/submenus/Vehicle/SavedVehicles.cpp
+++ b/src/game/frontend/submenus/Vehicle/SavedVehicles.cpp
@@ -13,61 +13,56 @@ namespace YimMenu::Submenus
 {
 	static BoolCommand spawnInsideSavedVehicle{"spawninsidesavedveh", "Spawn Inside", "Spawn inside the vehicle."};
 
+	namespace
+	{
+		// Get rid of the ".json" file extension so keep the saved car list a little cleaner
+		std::string GetDisplayName(const std::string& fileName)
+		{
+			constexpr std::string_view extension = ".json";
+			if (fileName.size() > extension.size() && std::string_view(fileName).ends_with(extension))
+				return fileName.substr(0, fileName.size() - extension.size());
+
+			return fileName;
+		}
+
+		std::string ToLower(std::string value)
+		{
+			std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+				return static_cast<char>(std::tolower(c));
+			});
+			return value;
+		}
+	}
+
 	std::shared_ptr<Category> BuildSavedVehiclesMenu()
 	{
 		static std::string folder{}, file{};
 		static std::vector<std::string> folders{}, files{};
-		static char vehicle_file_name_input[64]{};
-		static char newFolder[50]{};
+		static std::string vehicleFileNameInput{}, newFolder{}, search{};
 
 		auto persistCar = std::make_shared<Category>("Saved Vehicles");
 
 		persistCar->AddItem(std::make_shared<BoolCommandItem>("spawninsidesavedveh"_J));
 
 		persistCar->AddItem(std::make_unique<ImGuiItem>([] {
-			static auto drawSaveVehicleButton = [](bool saveToNewFolder) {
-				if (!Self::GetVehicle() || !Self::GetVehicle().IsValid())
-					return;
+			// Remove the need to refresh the list manually when the tab is opened
+			static int lastDrawnFrame = -1;
+			const int currentFrame = ImGui::GetFrameCount();
+			const bool justOpened = (currentFrame != lastDrawnFrame + 1);
+			lastDrawnFrame = currentFrame;
 
-				if (ImGui::Button("Save"))
-					FiberPool::Push([saveToNewFolder] {
-						std::string fileName = TrimString(vehicle_file_name_input);
-						strcpy(vehicle_file_name_input, "");
-
-						if (!fileName.size())
-						{
-							Notifications::Show("Saved Vehicles", "Filename empty!", NotificationType::Warning);
-							return;
-						}
-
-						SavedVehicles::Save(saveToNewFolder ? newFolder : folder, fileName);
-
-						if (saveToNewFolder)
-						{
-							folder = newFolder; // set current folder to newly created folder
-							strcpy(newFolder, "");
-						}
-
-						SavedVehicles::RefreshList(folder, folders, files);
-					});
-				ImGui::SameLine();
-				if (ImGui::Button("Populate Name"))
-					FiberPool::Push([] {
-						std::string name = Self::GetVehicle().GetFullName();
-						strcpy(vehicle_file_name_input, name.c_str());
-					});
-			};
-
-			if (ImGui::Button("Refresh List"))
+			if (justOpened)
 				FiberPool::Push([] {
 					SavedVehicles::RefreshList(folder, folders, files);
 				});
 
-			ImGui::SetNextItemWidth(300.f);
-			auto folder_display = folder.empty() ? "Root" : folder.c_str();
-			if (ImGui::BeginCombo("Folder", folder_display))
+			auto vehicle = Self::GetVehicle();
+			const bool inVehicle = vehicle.IsValid();
+
+			ImGui::SetNextItemWidth(240.f);
+			if (ImGui::BeginCombo("Folder", folder.empty() ? "Root" : folder.c_str()))
 			{
-				if (ImGui::Selectable("Root", folder == ""))
+				if (ImGui::Selectable("Root", folder.empty()))
 				{
 					folder.clear();
 					FiberPool::Push([] {
@@ -75,89 +70,151 @@ namespace YimMenu::Submenus
 					});
 				}
 
-				for (std::string folder_name : folders)
-					if (ImGui::Selectable(folder_name.c_str(), folder == folder_name))
+				for (const auto& folderName : folders)
+				{
+					if (ImGui::Selectable(folderName.c_str(), folder == folderName))
 					{
-						folder = folder_name;
+						folder = folderName;
 						FiberPool::Push([] {
 							SavedVehicles::RefreshList(folder, folders, files);
 						});
 					}
+				}
 
 				ImGui::EndCombo();
 			}
 
-			static bool open_modal = false;
-			static std::string search;
-
-			ImGui::SetNextItemWidth(300);
-			if (ImGui::InputTextWithHint("###veh_name", "Search", &search))
-				std::transform(search.begin(), search.end(), search.begin(), tolower);
-
-			ImGui::Text("Saved Vehicles");
-
-			static const auto over_30 = (30 * ImGui::GetTextLineHeightWithSpacing() + 2);
-			const auto box_height = files.size() <= 30 ? (files.size() * ImGui::GetTextLineHeightWithSpacing() + 2) : over_30;
-			ImGui::SetNextItemWidth(250);
-			if (ImGui::BeginListBox("##saved_vehs", ImVec2(300, box_height)))
-			{
-				for (const auto& pair : files)
-				{
-					std::string pair_lower = pair;
-					std::transform(pair_lower.begin(), pair_lower.end(), pair_lower.begin(), tolower);
-					if (pair_lower.contains(search))
-					{
-						auto file_name = pair.c_str();
-						if (ImGui::Selectable(file_name, file == pair, ImGuiSelectableFlags_AllowItemOverlap))
-						{
-							file = pair;
-							open_modal = true;
-						}
-					}
-				}
-				ImGui::EndListBox();
-			}
 			ImGui::SameLine();
-			ImGui::BeginGroup();
-			{
-				ImGui::Text("File Name");
-				ImGui::SetNextItemWidth(250);
-				ImGui::InputText("##vehiclefilename", vehicle_file_name_input, IM_ARRAYSIZE(vehicle_file_name_input));
+			if (ImGui::Button("Refresh List"))
+				FiberPool::Push([] {
+					SavedVehicles::RefreshList(folder, folders, files);
+				});
 
-				if (folder.empty())
+			ImGui::SameLine();
+			ImGui::TextDisabled("%d saved", static_cast<int>(files.size()));
+
+			ImGui::Spacing();
+
+			const float rowHeight = ImGui::GetTextLineHeightWithSpacing();
+			const float minPaneHeight = 8.f * rowHeight + ImGui::GetFrameHeightWithSpacing() * 2.5f;
+			const float paneHeight = std::max(ImGui::GetContentRegionAvail().y, minPaneHeight); // Since we can resize the YimMenu window, it's best to scale the panel height to the available Y-space
+			constexpr float listWidth = 340.f;
+
+			// Browser frame
+			if (ImGui::BeginChild("##saved_vehicles_list_pane", ImVec2(listWidth, paneHeight)))
+			{
+				ImGui::SeparatorText("Saved Vehicles");
+
+				ImGui::SetNextItemWidth(-FLT_MIN);
+				ImGui::InputTextWithHint("##veh_search", "Search", &search);
+
+				const std::string searchLower = ToLower(search);
+
+				if (ImGui::BeginListBox("##saved_vehs", ImVec2(-FLT_MIN, -FLT_MIN)))
 				{
-					ImGui::Text("Folder Name");
-					ImGui::SetNextItemWidth(250);
-					ImGui::InputText("##foldername", newFolder, IM_ARRAYSIZE(newFolder));
-					drawSaveVehicleButton(true);
+					bool anyVisible = false;
+
+					for (const auto& fileName : files)
+					{
+						const std::string displayName = GetDisplayName(fileName);
+
+						if (!searchLower.empty() && !ToLower(displayName).contains(searchLower))
+							continue;
+
+						anyVisible = true;
+
+						ImGui::PushID(fileName.c_str());
+						if (ImGui::Selectable(displayName.c_str(), file == fileName))
+						{
+							file = fileName;
+
+							// With this change we're going to spawn immediately without asking for a yes/no confirmation
+							FiberPool::Push([selectedFolder = folder, selectedFile = fileName] {
+								SavedVehicles::Load(selectedFolder, selectedFile, spawnInsideSavedVehicle.GetState());
+							});
+						}
+						if (ImGui::IsItemHovered())
+							ImGui::SetTooltip("Click to spawn %s", displayName.c_str());
+						ImGui::PopID();
+					}
+
+					if (!anyVisible)
+						ImGui::TextDisabled(files.empty() ? "  No saved vehicles in this folder." : "  No matches."); // Provide some feedback to the user so they're not just seeing an empty panel without explanation
+
+					ImGui::EndListBox();
+				}
+			}
+			ImGui::EndChild();
+
+			ImGui::SameLine();
+
+			if (ImGui::BeginChild("##saved_vehicles_save_pane", ImVec2(0.f, paneHeight)))
+			{
+				ImGui::SeparatorText("Save Current Vehicle");
+
+				if (!inVehicle)
+				{
+					ImGui::TextDisabled("Get into a vehicle to save it.");
 				}
 				else
-					drawSaveVehicleButton(false);
-			}
-			ImGui::EndGroup();
+				{
+					const bool savingToNewFolder = folder.empty();
 
-			if (open_modal)
-				ImGui::OpenPopup("##spawncarmodel2");
-			if (ImGui::BeginPopupModal("##spawncarmodel2", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
-			{
-				ImGui::Text("Are you sure you want to spawn %s", file.c_str());
-				ImGui::Spacing();
-				if (ImGui::Button("Yes"))
-				{
-					FiberPool::Push([] {
-						SavedVehicles::Load(folder, file, spawnInsideSavedVehicle.GetState());
-					});
-					open_modal = false;
-					ImGui::CloseCurrentPopup();
+					ImGui::Text("File Name");
+					ImGui::SetNextItemWidth(250.f);
+					ImGui::InputTextWithHint("##vehiclefilename", "Name this vehicle", &vehicleFileNameInput);
+
+					if (savingToNewFolder)
+					{
+						ImGui::Text("Folder Name");
+						ImGui::SetNextItemWidth(250.f);
+						ImGui::InputTextWithHint("##foldername", "Leave empty for Root", &newFolder);
+					}
+
+					ImGui::Spacing();
+
+					if (ImGui::Button("Save"))
+					{
+						const std::string fileName = TrimString(vehicleFileNameInput);
+
+						if (fileName.empty())
+						{
+							Notifications::Show("Saved Vehicles", "Filename empty!", NotificationType::Warning);
+						}
+						else
+						{
+							const std::string targetFolder = savingToNewFolder ? newFolder : folder;
+
+							vehicleFileNameInput.clear();
+
+							if (savingToNewFolder)
+							{
+								folder = newFolder; // jump to the folder we just saved into
+								newFolder.clear();
+							}
+
+							FiberPool::Push([targetFolder, fileName] {
+								SavedVehicles::Save(targetFolder, fileName);
+								SavedVehicles::RefreshList(folder, folders, files);
+							});
+						}
+					}
+
+					ImGui::SameLine();
+					if (ImGui::Button("Populate Name"))
+						FiberPool::Push([] {
+							vehicleFileNameInput = Self::GetVehicle().GetFullName();
+						});
 				}
-				ImGui::SameLine();
-				if (ImGui::Button("No"))
+
+				if (!file.empty())
 				{
-					open_modal = false;
-					ImGui::CloseCurrentPopup();
+					ImGui::Spacing();
+					ImGui::SeparatorText("Last Spawned");
+					ImGui::TextWrapped("%s", GetDisplayName(file).c_str());
 				}
-				ImGui::EndPopup();
 			}
+			ImGui::EndChild();
 		}));
 
 		return persistCar;

--- a/src/game/frontend/submenus/Vehicle/VehicleEditor.cpp
+++ b/src/game/frontend/submenus/Vehicle/VehicleEditor.cpp
@@ -199,10 +199,16 @@ namespace YimMenu::Submenus
 				}
 				ImGui::SeparatorText("Mod Options");
 				{
-					if (ImGui::Checkbox("Burstible tires", (bool*)&owned_mods[(int)CustomVehicleModType::MOD_TIRE_CAN_BURST]))
+					bool bulletproof_tires = !owned_mods[(int)CustomVehicleModType::MOD_TIRE_CAN_BURST];
+
+					if (ImGui::Checkbox("Bulletproof Tires", &bulletproof_tires))
+					{
+						owned_mods[(int)CustomVehicleModType::MOD_TIRE_CAN_BURST] = !bulletproof_tires;
+
 						FiberPool::Push([] {
 							VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(currentVeh, owned_mods[(int)CustomVehicleModType::MOD_TIRE_CAN_BURST]);
 						});
+					}
 					ImGui::SameLine();
 					if (ImGui::Checkbox("Low Grip Tires", (bool*)&owned_mods[(int)CustomVehicleModType::MOD_DRIFT_TIRE]))
 
@@ -353,24 +359,45 @@ namespace YimMenu::Submenus
 						}
 					}
 				}
-				ImGui::SeparatorText("Extras");
+
+				bool has_extras = false;
+
+				for (int extra = (int)CustomVehicleModType::MOD_EXTRA_1; extra >= (int)CustomVehicleModType::MOD_EXTRA_14; extra--)
 				{
+					if (owned_mods.find(extra) != owned_mods.end())
+					{
+						has_extras = true;
+						break;
+					}
+				}
+
+				if (has_extras)
+				{
+					ImGui::SeparatorText("Extras");
+
 					for (int extra = (int)CustomVehicleModType::MOD_EXTRA_1; extra >= (int)CustomVehicleModType::MOD_EXTRA_14; extra--)
+					{
 						if (owned_mods.find(extra) != owned_mods.end())
 						{
 							int id = (extra - (int)CustomVehicleModType::MOD_EXTRA_1) * -1;
 							bool is_extra_enabled = owned_mods[extra] == 1;
+
 							if (ImGui::Checkbox(std::format("{}###extra{}", id, id).c_str(), &is_extra_enabled))
 							{
 								owned_mods[extra] = is_extra_enabled;
+
 								FiberPool::Push([id, is_extra_enabled] {
 									VEHICLE::SET_VEHICLE_EXTRA(currentVeh, id, !is_extra_enabled);
 								});
 							}
+
 							ImGui::SameLine();
 						}
+					}
+
 					ImGui::NewLine();
 				}
+
 				ImGui::SeparatorText("Neon Light Options");
 				{
 					ImGui::PushID("##headlight_en");
@@ -598,7 +625,7 @@ namespace YimMenu::Submenus
 
 						ImGui::SameLine();
 						ImGui::SetNextItemWidth(214);
-						if (ImGui::ColorPicker3("Custom Vehicle Color", color, ImGuiColorEditFlags_NoAlpha | ImGuiColorEditFlags_NoDragDrop | ImGuiColorEditFlags_NoOptions | ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_DisplayHSV | ImGuiColorEditFlags_InputHSV | ImGuiColorEditFlags_DisplayHex))
+						if (ImGui::ColorPicker3("Custom Vehicle Color", color, ImGuiColorEditFlags_NoAlpha | ImGuiColorEditFlags_NoDragDrop | ImGuiColorEditFlags_NoOptions | ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_DisplayHex))
 						{
 							*color_r = (int)(color[0] * 255);
 							*color_g = (int)(color[1] * 255);

--- a/src/game/gta/Vehicle.cpp
+++ b/src/game/gta/Vehicle.cpp
@@ -108,12 +108,69 @@ namespace YimMenu
 
 		VEHICLE::SET_VEHICLE_MOD_KIT(veh, 0);
 
-		for (int t = (int)VehicleModType::MOD_SPOILERS; t < (int)VehicleModType::MOD_LIGHTBAR; t++)
+		for (int t = static_cast<int>(VehicleModType::MOD_SPOILERS); t < static_cast<int>(VehicleModType::MOD_LIGHTBAR); t++)
 		{
-			VEHICLE::SET_VEHICLE_MOD(veh, t, VEHICLE::GET_NUM_VEHICLE_MODS(veh, t) - 1, false);
+			switch (t)
+			{
+			// Handle edge cases for special mod slike horns and turbo
+			case static_cast<int>(VehicleModType::MOD_HORNS):
+				VEHICLE::SET_VEHICLE_MOD(veh, t, static_cast<int>(VehicleModHorns::HORN_SANANDREAS_LOOP), false);
+				continue;
+			case static_cast<int>(VehicleModType::MOD_TURBO):
+				VEHICLE::TOGGLE_VEHICLE_MOD(veh, t, true);
+				continue;
+			case static_cast<int>(VehicleModType::MOD_TYRE_SMOKE):
+				VEHICLE::SET_VEHICLE_TYRE_SMOKE_COLOR(veh, 0, 0, 0);
+				VEHICLE::TOGGLE_VEHICLE_MOD(veh, t, 1);
+				continue;
+			case static_cast<int>(VehicleModType::MOD_XENON_LIGHTS):
+				VEHICLE::TOGGLE_VEHICLE_MOD(veh, t, true);
+				continue;
+			default:
+				VEHICLE::SET_VEHICLE_MOD(veh, t, VEHICLE::GET_NUM_VEHICLE_MODS(veh, t) - 1, false);
+			}
 		}
 
+		VEHICLE::SET_VEHICLE_WINDOW_TINT(veh, 1); // Pure black
+
+		for (int i = 0; i < 4; i++)
+		{
+			VEHICLE::SET_VEHICLE_NEON_ENABLED(veh, i, true);
+		}
+
+		
+		VEHICLE::SET_VEHICLE_NEON_COLOUR(veh, 255, 255, 255);
+
+		// Extras?
+		/*
+		for (int a = 0; a < 16; a++)
+		{
+			if (VEHICLE::DOES_EXTRA_EXIST(veh, a))
+			{
+				VEHICLE::SET_VEHICLE_EXTRA(veh, a, false);
+			}
+		}
+		*/
+
 		VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(veh, false);
+
+		// Fix any vehicle damage at the same time
+		VEHICLE::SET_VEHICLE_FIXED(veh);
+		VEHICLE::SET_VEHICLE_DEFORMATION_FIXED(veh);
+		VEHICLE::SET_VEHICLE_NEEDS_TO_BE_HOTWIRED(veh, false);
+
+		if (FIRE::IS_ENTITY_ON_FIRE(veh))
+			FIRE::STOP_ENTITY_FIRE(veh);
+
+		VEHICLE::SET_VEHICLE_ENGINE_HEALTH(veh, 1000.0f);
+		VEHICLE::SET_VEHICLE_PETROL_TANK_HEALTH(veh, 1000.0f);
+		VEHICLE::SET_VEHICLE_BODY_HEALTH(veh, 1000.f);
+		VEHICLE::SET_VEHICLE_UNDRIVEABLE(veh, false);
+		VEHICLE::SET_VEHICLE_ENGINE_CAN_DEGRADE(veh, false);
+		VEHICLE::SET_VEHICLE_ENGINE_ON(veh, true, true, false);
+
+		VEHICLE::SET_VEHICLE_INDICATOR_LIGHTS(veh, 1, false);
+		VEHICLE::SET_VEHICLE_INDICATOR_LIGHTS(veh, 0, false);	
 	}
 
 	std::string Vehicle::GetPlateText()


### PR DESCRIPTION
I like the ability to save vehicles to json with YimMenuV2, but the current implementation is not particularly user-friendly and needs some polishing. Most of these changes are subjective, but I'm confident that they improve the user experience.

Here is a screenshot of how the reworked menu looks:
<img width="726" height="853" alt="image" src="https://github.com/user-attachments/assets/fe1c6f57-3d78-46fe-bde7-51c766ddebf3" />

Summary of changes:

- Rebuilt Saved Vehicles page for a cleaner and more organized look

- More verbose text feedback throughout the vehicle save workflow

- Removed cumbersome "do you want to spawn" confirmation dialog when selecting a vehicle from the list; now it's just a single click is required to spawn the vehicle. Spawning a vehicle is a low-risk low-impact event, so we don't need a confirmation dialog.

- Max Vehicle option in the Vehicle Editor is more comprehensive in applying its modifications (now includes tinted windows, xenon + neon lights, and a custom horn) and also repairs the vehicle

- Reworked "burstible tires" to "bulletproof tires" to better match in-game customization nomenclature and identify this feature as an upgrade rather than a default

- Vehicle Editor's "Extras" will no longer display a separator and blank space if there are no extras available to the vehicle

- Fixed the Vehicle Editor's color picker inconsistency due to RBG and HSV conflicts (only one of these flags should be pushed into ImGui's color picker)